### PR TITLE
Add community sanctions (GS) pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ htmlcov/
 
 # OS files
 .DS_Store
+
+# Git worktrees
+.worktrees/

--- a/bot.py
+++ b/bot.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-ClerkBot - AE protection actions logger
+ClerkBot - AE and GS protection actions logger
 
-This system monitors Wikipedia's protection log for arbitration enforcement (AE) actions
-and automatically appends them to a designated tracking page. It serves as an automated
-logging mechanism for Wikipedia administrators to maintain a centralized record of
-protection actions taken under arbitration enforcement authority.
+This system monitors Wikipedia's protection log for arbitration enforcement (AE) and
+community general sanctions (GS) actions and automatically appends them to designated
+tracking pages. It serves as an automated logging mechanism for Wikipedia administrators
+to maintain centralized records of protection actions taken under AE or GS authority.
 
 System Architecture:
 - Monitors MediaWiki's protection log (type=protect) and pending changes log (type=stable) via the API
@@ -39,6 +39,9 @@ Environment variables (all ASCII):
   CLERKBOT_CONFIG_URL         Optional. URL to fetch topics JSON (default: Wikipedia ClerkBot configuration URL)
   CLERKBOT_NOTIFY_ADMINS      Optional. Controls the notify-admin module. One of:
                               "false", "debug", or "true". Defaults to "debug" if unset/invalid.
+  CLERKBOT_GS_TARGET_PAGE        Optional. Target page for GS entries (empty = GS disabled)
+  CLERKBOT_GS_NOTIFY_ADMINS      Optional. Notification mode for GS pipeline ("false", "debug", "true")
+  CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE  Optional. Debug notification page for GS
 
 The target page must begin with a line like:
   Last updated: 19:32, 19 August 2025 (UTC)

--- a/bot.py
+++ b/bot.py
@@ -501,7 +501,7 @@ def main() -> int:
     """
     # Load topic detection data
     try:
-        detector = load_topics(config.config_url, config.user_agent)
+        ae_detector, _gs_detector = load_topics(config.config_url, config.user_agent)
     except Exception as error:
         log.error("Failed to load CTOP topics configuration from '%s': %s", config.config_url, error)
         return 2
@@ -527,7 +527,7 @@ def main() -> int:
 
     # Process new log entries
     new_entries, unclassified_by_admin = _process_new_log_entries(
-        site, detector, last_updated_dt, existing_logids
+        site, ae_detector, last_updated_dt, existing_logids
     )
 
     # Build updated page text

--- a/bot.py
+++ b/bot.py
@@ -250,7 +250,9 @@ def _notify_admins(
     unclassified_by_admin: Dict[str, List[Tuple[int, str, str]]],
     token: str,
     bot_usernames: Set[str],
-    config: BotConfig,
+    notify_mode: NotifyMode,
+    dryrun_page: str,
+    target_page: str,
 ) -> None:
     """
     Notify admins about protection actions that could not be automatically categorized.
@@ -259,9 +261,9 @@ def _notify_admins(
     to their talk page (or to a debug page) asking them to review the categorization.
     Bot accounts are automatically excluded from notifications.
 
-    Behavior depends on config.notify_mode:
+    Behavior depends on notify_mode:
       - DISABLED: No notifications sent, returns immediately
-      - DEBUG: All notifications appended to config.dryrun_page for testing
+      - DEBUG: All notifications appended to dryrun_page for testing
       - ENABLED: Notifications posted to individual admin talk pages
 
     Args:
@@ -270,13 +272,15 @@ def _notify_admins(
                                for actions that were newly logged but lack a topic code
         token: CSRF token for API edits
         bot_usernames: Set of usernames with bot rights (excluded from notifications)
-        config: Bot configuration
+        notify_mode: NotifyMode for this pipeline
+        dryrun_page: Page for debug notifications
+        target_page: Target page to include in notification text
 
     Returns:
         None
     """
-    if config.notify_mode == NotifyMode.DISABLED:
-        log.info("Notify-admin module disabled (CLERKBOT_NOTIFY_ADMINS=false).")
+    if notify_mode == NotifyMode.DISABLED:
+        log.info("Notify-admin module disabled.")
         return
     if not unclassified_by_admin:
         log.info("Notify-admin module: no unclassified actions to notify.")
@@ -288,13 +292,13 @@ def _notify_admins(
         if admin in bot_usernames:
             log.debug("Notify-admin: skipping bot account %s", admin)
             continue
-        text = _build_notification_text(admin, items, config.target_page)
-        if config.notify_mode == NotifyMode.DEBUG:
-            dest_title = config.dryrun_page
-            summary = f"DEBUG: AE protection categorization notice for {admin}"
+        text = _build_notification_text(admin, items, target_page)
+        if notify_mode == NotifyMode.DEBUG:
+            dest_title = dryrun_page
+            summary = f"DEBUG: protection categorization notice for {admin}"
         else:
             dest_title = f"User talk:{admin}"
-            summary = "adding AE protection categorization notice ([[User:ClerkBot#t3|bot task 3]])"
+            summary = "adding protection categorization notice ([[User:ClerkBot#t3|bot task 3]])"
         try:
             log.info("Posting notification (%d item(s)) to %s", len(items), dest_title)
             site.api(
@@ -569,7 +573,7 @@ def _run_pipeline(
     # Only notify for actions that were newly appended in this run
     if new_entries and unclassified_by_admin:
         token = site.get_token('csrf')
-        _notify_admins(site, unclassified_by_admin, token, bot_usernames, config)
+        _notify_admins(site, unclassified_by_admin, token, bot_usernames, notify_mode, dryrun_page, target_page)
     else:
         log.info("Notify-admin module: nothing to notify.")
 

--- a/bot.py
+++ b/bot.py
@@ -417,13 +417,14 @@ def _process_new_log_entries(
     return new_entries, unclassified_by_admin
 
 
-def _build_updated_page_text(text: str, new_entries: List[str]) -> str:
+def _build_updated_page_text(text: str, new_entries: List[str], pipeline_label: str = "AE") -> str:
     """
     Build updated page content with new entries and updated timestamp.
 
     Args:
         text: Current page text
         new_entries: List of new entry template strings to append
+        pipeline_label: Label for log messages (e.g. "AE" or "GS")
 
     Returns:
         Updated page text with new entries, updated timestamp, and footer repositioned
@@ -449,7 +450,7 @@ def _build_updated_page_text(text: str, new_entries: List[str]) -> str:
         append_block = "\n".join(new_entries) + "\n"
         new_text = new_text + append_block
     else:
-        log.info("No new AE protection actions to append.")
+        log.info("No new %s protection actions to append.", pipeline_label)
 
     # Re-add the footer marker at the very end, after all entries
     # This ensures the page structure remains: header -> entries -> footer
@@ -461,7 +462,7 @@ def _build_updated_page_text(text: str, new_entries: List[str]) -> str:
     return new_text
 
 
-def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_entries: List[str], base_revid: int) -> None:
+def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_entries: List[str], base_revid: int, pipeline_label: str = "AE") -> None:
     """
     Save the updated page text to Wikipedia with edit conflict detection.
 
@@ -471,6 +472,7 @@ def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_
         new_text: The complete new page text to save
         new_entries: List of new entries (used for edit summary)
         base_revid: The revision ID that the edit is based on (for conflict detection)
+        pipeline_label: Label for edit summaries (e.g. "AE" or "GS")
 
     Returns:
         None
@@ -479,7 +481,7 @@ def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_
         mwclient.errors.EditError: If an edit conflict occurs or other API error
     """
     edit_summary = (
-        f"updating AE protection log"
+        f"updating {pipeline_label} protection log"
         f"{f' ({len(new_entries)} new entries)' if new_entries else ''}"
         " ([[User:ClerkBot#t3|bot task 3]])"
     )
@@ -511,7 +513,7 @@ def _run_pipeline(
     notify_mode: NotifyMode,
     dryrun_page: str,
     bot_usernames: Set[str],
-    config: BotConfig,
+    pipeline_label: str = "AE",
 ) -> int:
     """
     Run one pipeline (AE or GS).
@@ -527,7 +529,7 @@ def _run_pipeline(
         notify_mode: NotifyMode for admin notifications
         dryrun_page: Page for debug notifications
         bot_usernames: Set of bot usernames to exclude from notifications
-        config: Full BotConfig (for notification text building)
+        pipeline_label: Label for edit summaries and log messages (e.g. "AE" or "GS")
 
     Returns:
         0 on success, 2 on setup error, 1 on API error
@@ -554,7 +556,7 @@ def _run_pipeline(
     )
 
     # Build updated page text
-    new_text = _build_updated_page_text(text, new_entries)
+    new_text = _build_updated_page_text(text, new_entries, pipeline_label)
 
     # If nothing changed at all, bail out
     if new_text == text:
@@ -563,7 +565,7 @@ def _run_pipeline(
 
     # Save the updated page
     try:
-        _save_page_update(site, target_page, new_text, new_entries, base_revid)
+        _save_page_update(site, target_page, new_text, new_entries, base_revid, pipeline_label)
     except mwclient.errors.EditError as e:
         log.error("Failed to save page due to edit conflict or error: %s", e)
         log.error("Another user may have edited the page. Please re-run the bot.")
@@ -609,7 +611,7 @@ def main() -> int:
         notify_mode=config.notify_mode,
         dryrun_page=config.dryrun_page,
         bot_usernames=bot_usernames,
-        config=config,
+        pipeline_label="AE",
     )
     if ae_result != 0:
         return ae_result
@@ -624,7 +626,7 @@ def main() -> int:
             notify_mode=config.gs_notify_mode,
             dryrun_page=config.gs_dryrun_page,
             bot_usernames=bot_usernames,
-            config=config,
+            pipeline_label="GS",
         )
         if gs_result != 0:
             return gs_result

--- a/bot.py
+++ b/bot.py
@@ -60,7 +60,7 @@ from mwclient.page import Page as MWPage
 from clerkbot.config import BotConfig, NotifyMode
 from clerkbot.constants import ENTRY_LOGID_RE, FOOTER_MARK
 from clerkbot.entries import format_entry
-from clerkbot.filters import is_arbitration_enforcement
+from clerkbot.filters import is_arbitration_enforcement, is_community_sanction
 from clerkbot.timestamp import (
     LAST_UPDATED_RE,
     clean_invisible_unicode,
@@ -309,16 +309,18 @@ def _notify_admins(
 def _process_single_log_event(
     log_event: dict,
     detector: TopicDetector,
+    filter_fn,
     existing_logids: set,
     new_entries: List[str],
     unclassified_by_admin: Dict[str, List[Tuple[int, str, str]]],
 ) -> None:
     """
-    Process a single log event and append to new_entries if it's an AE action.
+    Process a single log event and append to new_entries if it passes the filter.
 
     Args:
         log_event: A log event dict from the MediaWiki API
         detector: TopicDetector instance for categorizing actions
+        filter_fn: Callable(str) -> bool, the filter to apply to comments
         existing_logids: Set of log IDs already present on the page
         new_entries: List to append new entry strings to (modified in place)
         unclassified_by_admin: Map to track unclassified actions (modified in place)
@@ -330,9 +332,9 @@ def _process_single_log_event(
         # Already logged
         return
 
-    # Arbitration enforcement filter
+    # Apply the pipeline-specific filter
     comment = log_event.get("comment") or ""
-    if not is_arbitration_enforcement(comment):
+    if not filter_fn(comment):
         return
 
     topic_code = detector.detect(comment)
@@ -368,6 +370,7 @@ def _get_event_sort_key(log_event: dict) -> float:
 def _process_new_log_entries(
     site: mwclient.Site,
     detector: TopicDetector,
+    filter_fn,
     last_updated_dt: datetime,
     existing_logids: set,
 ) -> Tuple[List[str], Dict[str, List[Tuple[int, str, str]]]]:
@@ -378,6 +381,7 @@ def _process_new_log_entries(
     Args:
         site: The mwclient Site connection
         detector: TopicDetector instance for categorizing actions
+        filter_fn: Callable(str) -> bool, the filter to apply to comments
         last_updated_dt: Only process events after this timestamp
         existing_logids: Set of log IDs already present on the page
 
@@ -400,7 +404,7 @@ def _process_new_log_entries(
     # Process events in chronological order
     for log_event in all_events:
         _process_single_log_event(
-            log_event, detector, existing_logids, new_entries, unclassified_by_admin
+            log_event, detector, filter_fn, existing_logids, new_entries, unclassified_by_admin
         )
 
     return new_entries, unclassified_by_admin
@@ -492,33 +496,45 @@ def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_
         raise
 
 
-def main() -> int:
+def _run_pipeline(
+    site: mwclient.Site,
+    detector: "TopicDetector",
+    filter_fn,
+    target_page: str,
+    notify_mode: NotifyMode,
+    dryrun_page: str,
+    bot_usernames: Set[str],
+    config: BotConfig,
+) -> int:
     """
-    Main entry point for the ClerkBot AE protection log updater.
+    Run one pipeline (AE or GS).
+
+    Fetches the target page, scans log events through the filter,
+    detects topics, builds updated page text, and saves.
+
+    Args:
+        site: Authenticated mwclient Site
+        detector: TopicDetector for categorizing actions
+        filter_fn: Callable(str) -> bool, the filter to apply to comments
+        target_page: Wiki page title to update
+        notify_mode: NotifyMode for admin notifications
+        dryrun_page: Page for debug notifications
+        bot_usernames: Set of bot usernames to exclude from notifications
+        config: Full BotConfig (for notification text building)
 
     Returns:
-        0 on success, 2 on configuration/setup error, 1 on API error
+        0 on success, 2 on setup error, 1 on API error
     """
-    # Load topic detection data
-    try:
-        ae_detector, _gs_detector = load_topics(config.config_url, config.user_agent)
-    except Exception as error:
-        log.error("Failed to load CTOP topics configuration from '%s': %s", config.config_url, error)
-        return 2
-
-    # Connect to Wikipedia and load the target page
-    site = connect_site(config)
-    bot_usernames = fetch_bot_usernames(site)
-    page, base_revid = fetch_target_page(site, config.target_page)
+    page, base_revid = fetch_target_page(site, target_page)
     if not page.exists:
-        log.error("Target page '%s' does not exist. Create it first with the 'Last updated:' line.", config.target_page)
+        log.error("Target page '%s' does not exist. Create it first with the 'Last updated:' line.", target_page)
         return 2
 
     # Parse existing page content
     text = page.text()
     last_updated_dt = extract_last_updated(text)
     if not last_updated_dt:
-        log.error("Could not find 'Last updated: ... (UTC)' line at top of '%s'", config.target_page)
+        log.error("Could not find 'Last updated: ... (UTC)' line at top of '%s'", target_page)
         return 2
 
     existing_logids = extract_existing_logids(text)
@@ -527,7 +543,7 @@ def main() -> int:
 
     # Process new log entries
     new_entries, unclassified_by_admin = _process_new_log_entries(
-        site, ae_detector, last_updated_dt, existing_logids
+        site, detector, filter_fn, last_updated_dt, existing_logids
     )
 
     # Build updated page text
@@ -540,7 +556,7 @@ def main() -> int:
 
     # Save the updated page
     try:
-        _save_page_update(site, config.target_page, new_text, new_entries, base_revid)
+        _save_page_update(site, target_page, new_text, new_entries, base_revid)
     except mwclient.errors.EditError as e:
         log.error("Failed to save page due to edit conflict or error: %s", e)
         log.error("Another user may have edited the page. Please re-run the bot.")
@@ -553,6 +569,58 @@ def main() -> int:
         _notify_admins(site, unclassified_by_admin, token, bot_usernames, config)
     else:
         log.info("Notify-admin module: nothing to notify.")
+
+    return 0
+
+
+def main() -> int:
+    """
+    Main entry point for the ClerkBot protection log updater.
+
+    Runs the AE pipeline (always), then the GS pipeline (if configured).
+
+    Returns:
+        0 on success, 2 on configuration/setup error, 1 on API error
+    """
+    # Load topic detection data
+    try:
+        ae_detector, gs_detector = load_topics(config.config_url, config.user_agent)
+    except Exception as error:
+        log.error("Failed to load CTOP topics configuration from '%s': %s", config.config_url, error)
+        return 2
+
+    # Connect to Wikipedia and load shared data
+    site = connect_site(config)
+    bot_usernames = fetch_bot_usernames(site)
+
+    # AE pipeline (always runs)
+    ae_result = _run_pipeline(
+        site=site,
+        detector=ae_detector,
+        filter_fn=is_arbitration_enforcement,
+        target_page=config.target_page,
+        notify_mode=config.notify_mode,
+        dryrun_page=config.dryrun_page,
+        bot_usernames=bot_usernames,
+        config=config,
+    )
+    if ae_result != 0:
+        return ae_result
+
+    # GS pipeline (only if configured)
+    if config.gs_target_page:
+        gs_result = _run_pipeline(
+            site=site,
+            detector=gs_detector,
+            filter_fn=is_community_sanction,
+            target_page=config.gs_target_page,
+            notify_mode=config.gs_notify_mode,
+            dryrun_page=config.gs_dryrun_page,
+            bot_usernames=bot_usernames,
+            config=config,
+        )
+        if gs_result != 0:
+            return gs_result
 
     return 0
 

--- a/bot.py
+++ b/bot.py
@@ -53,7 +53,7 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Set, Tuple
 
 # Third-party imports
 import mwclient
@@ -316,7 +316,7 @@ def _notify_admins(
 def _process_single_log_event(
     log_event: dict,
     detector: TopicDetector,
-    filter_fn,
+    filter_fn: Callable[[str], bool],
     existing_logids: set,
     new_entries: List[str],
     unclassified_by_admin: Dict[str, List[Tuple[int, str, str]]],
@@ -377,7 +377,7 @@ def _get_event_sort_key(log_event: dict) -> float:
 def _process_new_log_entries(
     site: mwclient.Site,
     detector: TopicDetector,
-    filter_fn,
+    filter_fn: Callable[[str], bool],
     last_updated_dt: datetime,
     existing_logids: set,
 ) -> Tuple[List[str], Dict[str, List[Tuple[int, str, str]]]]:
@@ -508,7 +508,7 @@ def _save_page_update(site: mwclient.Site, target_page: str, new_text: str, new_
 def _run_pipeline(
     site: mwclient.Site,
     detector: "TopicDetector",
-    filter_fn,
+    filter_fn: Callable[[str], bool],
     target_page: str,
     notify_mode: NotifyMode,
     dryrun_page: str,

--- a/clerkbot/__init__.py
+++ b/clerkbot/__init__.py
@@ -9,7 +9,7 @@ designated tracking page.
 from clerkbot.config import BotConfig, NotifyMode
 from clerkbot.constants import AE_ENTRY_TEMPLATE, ENTRY_LOGID_RE, FOOTER_MARK, HEADER_MARK
 from clerkbot.entries import build_action_string, format_entry
-from clerkbot.filters import AE_TRIGGERS, is_arbitration_enforcement
+from clerkbot.filters import AE_TRIGGERS, is_arbitration_enforcement, GS_TRIGGERS, is_community_sanction
 from clerkbot.timestamp import (
     LAST_UPDATED_RE,
     clean_invisible_unicode,
@@ -37,6 +37,8 @@ __all__ = [
     # filters
     'AE_TRIGGERS',
     'is_arbitration_enforcement',
+    'GS_TRIGGERS',
+    'is_community_sanction',
     # timestamp
     'LAST_UPDATED_RE',
     'clean_invisible_unicode',

--- a/clerkbot/__init__.py
+++ b/clerkbot/__init__.py
@@ -1,9 +1,9 @@
 """
-ClerkBot - AE protection actions logger package.
+ClerkBot - AE and GS protection actions logger package.
 
 This package provides modules for monitoring Wikipedia's protection log for
-arbitration enforcement (AE) actions and automatically appending them to a
-designated tracking page.
+arbitration enforcement (AE) and community general sanctions (GS) actions
+and automatically appending them to designated tracking pages.
 """
 
 from clerkbot.config import BotConfig, NotifyMode

--- a/clerkbot/config.py
+++ b/clerkbot/config.py
@@ -38,6 +38,9 @@ class BotConfig:
         notify_mode: Admin notification mode (DISABLED/DEBUG/ENABLED)
         dryrun_page: Page for debug notifications
         log_level: Logging level (default: "INFO")
+        gs_target_page: Target wiki page for GS entries (CLERKBOT_GS_TARGET_PAGE), empty = disabled
+        gs_notify_mode: GS notification mode (default: DISABLED)
+        gs_dryrun_page: Page for GS debug notifications
     """
     # Required fields
     username: str
@@ -81,6 +84,9 @@ class BotConfig:
             CLERKBOT_NOTIFY_ADMINS (optional: "false", "debug", "true")
             CLERKBOT_NOTIFICATIONS_DRYRUN_PAGE (optional)
             CLERKBOT_LOG_LEVEL (optional, default: "INFO")
+            CLERKBOT_GS_TARGET_PAGE (optional, default: "" = GS disabled)
+            CLERKBOT_GS_NOTIFY_ADMINS (optional: "false", "debug", "true", default: "false")
+            CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE (optional)
 
         Returns:
             BotConfig instance

--- a/clerkbot/config.py
+++ b/clerkbot/config.py
@@ -53,10 +53,17 @@ class BotConfig:
     dryrun_page: str = field(default="")  # Computed from target_page if not set
     log_level: str = "INFO"
 
+    # GS pipeline fields (optional, disabled by default)
+    gs_target_page: str = ""
+    gs_notify_mode: NotifyMode = NotifyMode.DISABLED
+    gs_dryrun_page: str = field(default="")
+
     def __post_init__(self):
         """Set computed defaults after initialization."""
         if not self.dryrun_page:
             self.dryrun_page = f"{self.target_page}/notifications_dryrun"
+        if self.gs_target_page and not self.gs_dryrun_page:
+            self.gs_dryrun_page = f"{self.gs_target_page}/notifications_dryrun"
 
     @classmethod
     def from_environment(cls) -> "BotConfig":
@@ -115,6 +122,14 @@ class BotConfig:
         dryrun_page = os.environ.get("CLERKBOT_NOTIFICATIONS_DRYRUN_PAGE", "")
         log_level = os.environ.get("CLERKBOT_LOG_LEVEL", "INFO").upper()
 
+        # GS pipeline optional values
+        gs_target_page = os.environ.get("CLERKBOT_GS_TARGET_PAGE", "")
+        gs_notify_raw = (os.environ.get("CLERKBOT_GS_NOTIFY_ADMINS") or "").strip().lower()
+        if gs_notify_raw not in (NotifyMode.DISABLED.value, NotifyMode.DEBUG.value, NotifyMode.ENABLED.value):
+            gs_notify_raw = NotifyMode.DISABLED.value
+        gs_notify_mode = NotifyMode(gs_notify_raw)
+        gs_dryrun_page = os.environ.get("CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE", "")
+
         return cls(
             username=username,
             password=password,
@@ -126,6 +141,9 @@ class BotConfig:
             notify_mode=notify_mode,
             dryrun_page=dryrun_page,
             log_level=log_level,
+            gs_target_page=gs_target_page,
+            gs_notify_mode=gs_notify_mode,
+            gs_dryrun_page=gs_dryrun_page,
         )
 
 

--- a/clerkbot/filters.py
+++ b/clerkbot/filters.py
@@ -38,7 +38,37 @@ def is_arbitration_enforcement(comment: str) -> bool:
     return any(trigger in comment_lower for trigger in AE_TRIGGERS)
 
 
+GS_TRIGGERS = [
+    "general sanction",
+    "community sanction",
+    "community-designated contentious topic",
+    "wp:gs/",
+    "wikipedia:gs/",
+    "wp:gs|",
+    "wikipedia:gs|",
+    "wp:gs]",
+    "wikipedia:gs]",
+    "wikipedia:general sanctions/",
+]
+
+
+def is_community_sanction(comment: str) -> bool:
+    """
+    Check if a protection action comment indicates a community general sanction.
+
+    Args:
+        comment: The edit summary or log comment to check
+
+    Returns:
+        True if the comment contains any GS trigger phrases, False otherwise
+    """
+    comment_lower = (comment or "").lower()
+    return any(trigger in comment_lower for trigger in GS_TRIGGERS)
+
+
 __all__ = [
     'AE_TRIGGERS',
     'is_arbitration_enforcement',
+    'GS_TRIGGERS',
+    'is_community_sanction',
 ]

--- a/clerkbot/filters.py
+++ b/clerkbot/filters.py
@@ -1,8 +1,8 @@
 """
-Filtering logic for arbitration enforcement detection.
+Filtering logic for arbitration enforcement and community sanctions detection.
 
 Provides functions to detect whether a protection action is related to
-arbitration enforcement based on edit summary keywords.
+arbitration enforcement or community general sanctions based on edit summary keywords.
 """
 
 # AE trigger phrases (case-insensitive) to detect arbitration enforcement

--- a/clerkbot/filters.py
+++ b/clerkbot/filters.py
@@ -43,6 +43,7 @@ GS_TRIGGERS = [
     "community sanction",
     "community-designated contentious topic",
     "wp:gs/",
+    "wp:gs ",
     "wikipedia:gs/",
     "wp:gs|",
     "wikipedia:gs|",

--- a/clerkbot/topics.py
+++ b/clerkbot/topics.py
@@ -8,7 +8,7 @@ using multiple heuristics in priority order.
 import json
 import logging
 import re
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from urllib.request import Request, urlopen
 
 __all__ = [
@@ -99,7 +99,7 @@ class TopicDetector:
         return ""
 
 
-def load_topics(url: str, user_agent: str) -> tuple:
+def load_topics(url: str, user_agent: str) -> Tuple["TopicDetector", "TopicDetector"]:
     """
     Load topic detection configuration from a URL.
 

--- a/clerkbot/topics.py
+++ b/clerkbot/topics.py
@@ -1,5 +1,5 @@
 """
-Topic detection for CTOP (Contentious Topic) codes.
+Topic detection for CTOP (Contentious Topic) and GS (General Sanctions) codes.
 
 Provides TopicDetector class that detects topic codes from edit summaries
 using multiple heuristics in priority order.

--- a/clerkbot/topics.py
+++ b/clerkbot/topics.py
@@ -99,7 +99,7 @@ class TopicDetector:
         return ""
 
 
-def load_topics(url: str, user_agent: str) -> TopicDetector:
+def load_topics(url: str, user_agent: str) -> tuple:
     """
     Load topic detection configuration from a URL.
 
@@ -108,7 +108,7 @@ def load_topics(url: str, user_agent: str) -> TopicDetector:
         user_agent: User-Agent header for the request
 
     Returns:
-        TopicDetector instance configured with the fetched data
+        Tuple of (ae_detector, gs_detector) TopicDetector instances
 
     Raises:
         ValueError: If the configuration JSON is missing required keys
@@ -123,4 +123,13 @@ def load_topics(url: str, user_agent: str) -> TopicDetector:
     override_strings = data.get("override_strings", {})
     if not codes or not page_to_code:
         raise ValueError("Configuration JSON missing required keys 'codes' or 'specific_pages'")
-    return TopicDetector(codes=codes, page_to_code=page_to_code, override_strings=override_strings)
+
+    ae_detector = TopicDetector(codes=codes, page_to_code=page_to_code, override_strings=override_strings)
+
+    # GS detector — gracefully handle missing keys
+    gs_codes = data.get("gs_codes", [])
+    gs_page_to_code = data.get("gs_specific_pages", {})
+    gs_override_strings = data.get("gs_override_strings", {})
+    gs_detector = TopicDetector(codes=gs_codes, page_to_code=gs_page_to_code, override_strings=gs_override_strings)
+
+    return ae_detector, gs_detector

--- a/docs/plans/2026-03-26-gs-pipeline-design.md
+++ b/docs/plans/2026-03-26-gs-pipeline-design.md
@@ -1,0 +1,181 @@
+# Design: Community Sanctions (GS) Pipeline
+
+**Issue:** #5 — expand to cover CCTOPs and community ECRs
+**Date:** 2026-03-26
+**Approach:** Dual-pipeline (Approach A)
+
+## Overview
+
+Add a second parallel pipeline for community sanctions (General Sanctions / GS) alongside the existing AE pipeline. Both pipelines share core infrastructure (entry formatting, page updating, dedup) but have independent filtering, topic detection, and target page configuration.
+
+Covers all three types of community-authorised sanctions:
+- Community-designated contentious topics (CCTOPs)
+- Extended confirmed restrictions (ECRs)
+- Page-protection-only sanctions (e.g., Beauty Pageants)
+
+## Data from live Wikipedia
+
+Analysis of 5000 recent protect log events:
+- **707** match AE keywords only
+- **28** match GS keywords only
+- **68** match both (71% of all GS-related events)
+
+The dominant dual-match pattern is admins citing both authorities: `[[WP:CT/KURD]]/[[WP:GS/KURD]]`. This is common for topics like Kurds and Armenia-Azerbaijan that have both an ArbCom CTOP and a community GS.
+
+## Configuration
+
+### New environment variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `CLERKBOT_GS_TARGET_PAGE` | No | `""` (disabled) | Target page for GS entries. Empty = GS pipeline skipped. |
+| `CLERKBOT_GS_NOTIFY_ADMINS` | No | `"false"` | Notification mode for GS. Defaults to disabled. |
+| `CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE` | No | `{GS_TARGET_PAGE}/notifications_dryrun` | Debug notification page for GS. |
+| `CLERKBOT_GS_NOTIFY_TEMPLATE` | No | `""` | Reserved for future separate notification template (#19). |
+
+The GS pipeline is enabled when `gs_target_page` is non-empty.
+
+### On-wiki config.json changes
+
+Three new keys added to `User:ClerkBot/T3/config.json` alongside existing AE keys:
+
+```json
+{
+  "codes": ["ap", "blp", ...],
+  "specific_pages": { ... },
+  "override_strings": { ... },
+  "gs_codes": ["scw&isil", "crypto", "pw", "mj", "pageant", "rusukr", "uyghur", "aa", "kurd", "acas", "we"],
+  "gs_specific_pages": {
+    "Wikipedia:General sanctions/Syrian Civil War and Islamic State of Iraq and the Levant": "scw&isil",
+    "Wikipedia:General sanctions/Blockchain and cryptocurrencies": "crypto",
+    "Wikipedia:General sanctions/Professional wrestling": "pw",
+    "Wikipedia:General sanctions/Michael Jackson": "mj",
+    "Wikipedia:General sanctions/Armenia and Azerbaijan": "aa",
+    "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+    "Wikipedia:General sanctions/Assyrian, Chaldean, Aramean and Syriac topics": "acas",
+    "Wikipedia:General sanctions/Weather events": "we"
+  },
+  "gs_override_strings": {
+    "gs/scw": "scw&isil",
+    "gs/isil": "scw&isil",
+    "gs/crypto": "crypto",
+    "gs/pw": "pw",
+    "gs/mj": "mj",
+    "gs/pageant": "pageant",
+    "gs/rusukr": "rusukr",
+    "gs/uyghur": "uyghur",
+    "gs/aa": "aa",
+    "gs/kurd": "kurd",
+    "gs/acas": "acas",
+    "ct/we": "we"
+  }
+}
+```
+
+The bot gracefully handles absence of these keys (GS topic detection returns empty strings).
+
+## Filtering
+
+### New trigger phrases in `filters.py`
+
+```python
+GS_TRIGGERS = [
+    "general sanction",
+    "community sanction",
+    "community-designated contentious topic",
+    "wp:gs/",
+    "wikipedia:gs/",
+    "wp:gs|",
+    "wikipedia:gs|",
+    "wp:gs]",
+    "wikipedia:gs]",
+    "wikipedia:general sanctions/",
+]
+```
+
+`is_arbitration_enforcement()` is unchanged. `is_community_sanction()` is a new parallel function.
+
+### Dedup behavior for dual-match events
+
+Events matching both filters (71% of GS events) are handled by logid-based dedup:
+- **Separate pages:** Event appears on both logs (correct — it is both an AE and GS action).
+- **Same page:** AE pipeline runs first and logs it; GS pipeline sees it via `existing_logids` and skips.
+
+No special mutual-exclusion logic needed.
+
+## Topic Detection
+
+No changes to the `TopicDetector` class. `load_topics()` creates two instances from the same JSON:
+- AE detector: uses `codes`, `specific_pages`, `override_strings`
+- GS detector: uses `gs_codes`, `gs_specific_pages`, `gs_override_strings`
+
+`WP:GS/<code>` shortcuts are handled via `gs_override_strings` (e.g., `"gs/kurd": "kurd"`) rather than adding a new regex heuristic to the class.
+
+## Bot Orchestration
+
+### `_run_pipeline()` helper
+
+Extract pipeline logic into a reusable function:
+
+```python
+def _run_pipeline(
+    site, detector, filter_fn, target_page,
+    notify_mode, dryrun_page, bot_usernames, config
+) -> int:
+    """Run one pipeline (AE or GS). Returns 0 on success, nonzero on error."""
+```
+
+### `main()` flow
+
+```
+main()
+├── load config from env
+├── load merged topic config → ae_detector, gs_detector
+├── connect to Wikipedia
+├── fetch bot usernames (shared)
+│
+├── AE pipeline (always runs)
+│   └── _run_pipeline(ae_detector, is_arbitration_enforcement, ...)
+│
+├── GS pipeline (only if gs_target_page is set)
+│   └── _run_pipeline(gs_detector, is_community_sanction, ...)
+│
+└── return 0
+```
+
+Both pipelines independently call `enumerate_protect_logevents()` and `enumerate_stable_logevents()`. The API calls happen twice — slightly redundant but keeps pipelines independent and avoids caching complexity. The GS pipeline re-fetches its target page after AE saves, so it sees fresh content (important for the shared-page case).
+
+## Entry Format
+
+Both pipelines use `{{User:ClerkBot/AE entry}}`. No new template.
+
+## Notifications
+
+GS notifications default to disabled (`CLERKBOT_GS_NOTIFY_ADMINS=false`). A separate notification template is tracked in #19.
+
+## Testing
+
+1. **`test_filters.py`** — `is_community_sanction()`: matches GS triggers, rejects unrelated comments, no false positives from substrings like "recreated" containing "ecr".
+2. **`test_topic.py`** — GS `TopicDetector`: override strings, specific pages, bare codes.
+3. **`test_config.py`** — GS config fields: defaults, pipeline skip when empty.
+4. **`test_bot.py`** — `_run_pipeline()` and dual-pipeline orchestration: AE-only, GS-only, dual-match (separate pages), dual-match (shared page), GS skipped when unconfigured.
+
+Existing AE tests are unchanged.
+
+## Not in scope
+
+- Separate GS notification template (#19)
+- Separate entry template
+- Unified pipeline refactor (Approach B) — future work
+- On-wiki config.json edits — manual step after deploy
+- Year-month log suffix (#2)
+- Lua module / CSS filtering (#18)
+
+## Future: migrating to Approach B
+
+When the time comes to unify into a single pipeline:
+1. Merge filter functions into one returning a source tag (`"ae"` / `"gs"` / `None`)
+2. Collapse two `_run_pipeline` calls into one pass bucketing entries by source
+3. Route entries to target pages by source tag
+
+Estimated effort: half-day refactor. Nothing in Approach A prevents this.

--- a/docs/plans/2026-03-26-gs-pipeline-implementation.md
+++ b/docs/plans/2026-03-26-gs-pipeline-implementation.md
@@ -1,0 +1,966 @@
+# GS Pipeline Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a community sanctions (GS) pipeline alongside the existing AE pipeline, enabling the bot to log protection actions taken under community-designated contentious topics, extended confirmed restrictions, and other community general sanctions.
+
+**Architecture:** Dual-pipeline approach — a new `is_community_sanction()` filter and GS-specific `TopicDetector` run as a second pass after the existing AE pipeline. Both share entry formatting, page update, and dedup infrastructure. A `_run_pipeline()` helper is extracted from `main()` to avoid duplication.
+
+**Tech Stack:** Python 3, mwclient, pytest
+
+**Design doc:** `docs/plans/2026-03-26-gs-pipeline-design.md`
+
+---
+
+### Task 1: Add `is_community_sanction()` filter
+
+**Files:**
+- Modify: `clerkbot/filters.py`
+- Modify: `clerkbot/__init__.py`
+- Test: `tests/test_filters.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_filters.py`:
+
+```python
+from clerkbot.filters import GS_TRIGGERS, is_community_sanction
+
+
+class TestGSTriggers:
+    """Tests for GS_TRIGGERS constant."""
+
+    def test_triggers_list_not_empty(self):
+        assert len(GS_TRIGGERS) > 0
+
+    def test_triggers_are_lowercase(self):
+        for trigger in GS_TRIGGERS:
+            assert trigger == trigger.lower(), f"Trigger '{trigger}' is not lowercase"
+
+    def test_triggers_are_strings(self):
+        for trigger in GS_TRIGGERS:
+            assert isinstance(trigger, str)
+
+    def test_expected_triggers_present(self):
+        expected = ["general sanction", "wp:gs/", "wikipedia:general sanctions/"]
+        for trigger in expected:
+            assert trigger in GS_TRIGGERS, f"Expected trigger '{trigger}' not found"
+
+
+class TestIsCommunityGS:
+    """Tests for community sanction detection."""
+
+    def test_wp_gs_slash_trigger(self):
+        assert is_community_sanction("Per [[WP:GS/KURD]]")
+        assert is_community_sanction("[[WP:GS/AA]]")
+        assert is_community_sanction("wp:gs/acas")
+
+    def test_wikipedia_gs_slash_trigger(self):
+        assert is_community_sanction("[[Wikipedia:GS/KURD]]")
+
+    def test_wp_gs_bracket_trigger(self):
+        assert is_community_sanction("[[WP:GS]]")
+        assert is_community_sanction("[[WP:GS|community sanctions]]")
+
+    def test_full_page_name_trigger(self):
+        assert is_community_sanction("[[Wikipedia:General sanctions/Kurds and Kurdistan]]")
+        assert is_community_sanction("Wikipedia:General sanctions/Armenia and Azerbaijan")
+
+    def test_general_sanction_phrase(self):
+        assert is_community_sanction("Per general sanctions")
+        assert is_community_sanction("GENERAL SANCTION applies")
+
+    def test_community_sanction_phrase(self):
+        assert is_community_sanction("community sanction enforcement")
+        assert is_community_sanction("Community Sanction")
+
+    def test_community_designated_phrase(self):
+        assert is_community_sanction("community-designated contentious topic")
+
+    def test_case_insensitive(self):
+        assert is_community_sanction("WP:GS/KURD")
+        assert is_community_sanction("wp:gs/kurd")
+        assert is_community_sanction("Wp:Gs/Kurd")
+
+    def test_no_match(self):
+        assert not is_community_sanction("Regular vandalism protection")
+        assert not is_community_sanction("Requested at RFPP")
+        assert not is_community_sanction("")
+        assert not is_community_sanction(None)
+        assert not is_community_sanction("   ")
+
+    def test_no_false_positive_from_substrings(self):
+        """Ensure common words containing trigger substrings don't match."""
+        assert not is_community_sanction("Repeatedly recreated")
+        assert not is_community_sanction("persistent disruption")
+
+    def test_ae_only_comment_does_not_match(self):
+        """AE-only comments should not match the GS filter."""
+        assert not is_community_sanction("Per arbitration enforcement WP:CT/BLP")
+        assert not is_community_sanction("CTOP protection")
+
+    def test_dual_authority_comment_matches(self):
+        """Comments citing both AE and GS should match GS filter."""
+        assert is_community_sanction("[[WP:CT/KURD]]/[[WP:GS/KURD]]")
+        assert is_community_sanction("Arbitration enforcement - [[WP:CT/AA]]/[[WP:GS/AA]]")
+
+    def test_real_world_comments(self):
+        """Test against real edit summaries observed in the wild."""
+        assert is_community_sanction("Per [[WP:GS/KURD]]")
+        assert is_community_sanction("[[Wikipedia:General sanctions/Armenia and Azerbaijan]]")
+        assert is_community_sanction("[[WP:GS#Community sanctions|Community sanctions enforcement]]: WP:GS/KURD")
+        assert is_community_sanction("Enforcement for [[WP:GS/PW]]")
+        assert is_community_sanction("Persistent disruptive editing - [[WP:GS/MJ]]; requested at [[WP:RfPP]]")
+        assert is_community_sanction("[[WP:GS/RUSUKR]]")
+
+    def test_special_characters_in_comment(self):
+        assert is_community_sanction("[[WP:GS/KURD|community sanctions]]")
+        assert is_community_sanction("Protection: [[Wikipedia:General sanctions/Weather events]]")
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_filters.py -v -k "GS or CommunityGS" 2>&1 | tail -20`
+Expected: ImportError — `GS_TRIGGERS` and `is_community_sanction` don't exist yet.
+
+**Step 3: Implement the filter**
+
+Add to `clerkbot/filters.py` after the existing `is_arbitration_enforcement` function and `__all__`:
+
+```python
+GS_TRIGGERS = [
+    "general sanction",
+    "community sanction",
+    "community-designated contentious topic",
+    "wp:gs/",
+    "wikipedia:gs/",
+    "wp:gs|",
+    "wikipedia:gs|",
+    "wp:gs]",
+    "wikipedia:gs]",
+    "wikipedia:general sanctions/",
+]
+
+
+def is_community_sanction(comment: str) -> bool:
+    """
+    Check if a protection action comment indicates a community general sanction.
+
+    Args:
+        comment: The edit summary or log comment to check
+
+    Returns:
+        True if the comment contains any GS trigger phrases, False otherwise
+    """
+    comment_lower = (comment or "").lower()
+    return any(trigger in comment_lower for trigger in GS_TRIGGERS)
+```
+
+Update `__all__` in `clerkbot/filters.py` to include `'GS_TRIGGERS'` and `'is_community_sanction'`.
+
+Update `clerkbot/__init__.py` to import and re-export `GS_TRIGGERS` and `is_community_sanction`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_filters.py -v 2>&1 | tail -30`
+Expected: All tests PASS, including both existing AE tests and new GS tests.
+
+**Step 5: Commit**
+
+```bash
+git add clerkbot/filters.py clerkbot/__init__.py tests/test_filters.py
+git commit -m "Add is_community_sanction() filter for GS pipeline (#5)"
+```
+
+---
+
+### Task 2: Add GS fields to `BotConfig`
+
+**Files:**
+- Modify: `clerkbot/config.py`
+- Test: `tests/test_config.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+class TestBotConfigGS:
+    """Tests for GS-related configuration fields."""
+
+    def test_gs_defaults_when_not_set(self):
+        """GS pipeline defaults to disabled."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/Log"
+        )
+        assert config.gs_target_page == ""
+        assert config.gs_notify_mode == NotifyMode.DISABLED
+        assert config.gs_dryrun_page == ""
+
+    def test_gs_dryrun_page_computed(self):
+        """gs_dryrun_page is computed from gs_target_page if not set."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log"
+        )
+        assert config.gs_dryrun_page == "User:Bot/GS Log/notifications_dryrun"
+
+    def test_gs_dryrun_page_explicit(self):
+        """Explicit gs_dryrun_page is preserved."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log",
+            gs_dryrun_page="User:Bot/GS Dryrun"
+        )
+        assert config.gs_dryrun_page == "User:Bot/GS Dryrun"
+
+    def test_gs_dryrun_page_empty_when_gs_disabled(self):
+        """gs_dryrun_page stays empty when gs_target_page is empty."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/Log",
+            gs_target_page=""
+        )
+        assert config.gs_dryrun_page == ""
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+    }, clear=True)
+    def test_from_environment_gs_disabled_by_default(self):
+        """GS pipeline is disabled when env vars are not set."""
+        config = BotConfig.from_environment()
+        assert config.gs_target_page == ""
+        assert config.gs_notify_mode == NotifyMode.DISABLED
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+        "CLERKBOT_GS_TARGET_PAGE": "User:TestBot/GS log",
+        "CLERKBOT_GS_NOTIFY_ADMINS": "debug",
+        "CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE": "User:TestBot/GS dryrun",
+    }, clear=True)
+    def test_from_environment_gs_full(self):
+        """GS configuration is loaded from environment."""
+        config = BotConfig.from_environment()
+        assert config.gs_target_page == "User:TestBot/GS log"
+        assert config.gs_notify_mode == NotifyMode.DEBUG
+        assert config.gs_dryrun_page == "User:TestBot/GS dryrun"
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+        "CLERKBOT_GS_TARGET_PAGE": "User:TestBot/GS log",
+        "CLERKBOT_GS_NOTIFY_ADMINS": "invalid",
+    }, clear=True)
+    def test_from_environment_gs_invalid_notify_defaults_disabled(self):
+        """Invalid GS notify mode defaults to DISABLED (not DEBUG like AE)."""
+        config = BotConfig.from_environment()
+        assert config.gs_notify_mode == NotifyMode.DISABLED
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_config.py -v -k "GS" 2>&1 | tail -20`
+Expected: TypeError — `gs_target_page` is not a known field.
+
+**Step 3: Implement config changes**
+
+In `clerkbot/config.py`, add to `BotConfig` dataclass after the existing optional fields:
+
+```python
+    # GS pipeline fields (optional, disabled by default)
+    gs_target_page: str = ""
+    gs_notify_mode: NotifyMode = NotifyMode.DISABLED
+    gs_dryrun_page: str = field(default="")
+```
+
+Update `__post_init__` to handle `gs_dryrun_page`:
+
+```python
+    def __post_init__(self):
+        """Set computed defaults after initialization."""
+        if not self.dryrun_page:
+            self.dryrun_page = f"{self.target_page}/notifications_dryrun"
+        if self.gs_target_page and not self.gs_dryrun_page:
+            self.gs_dryrun_page = f"{self.gs_target_page}/notifications_dryrun"
+```
+
+Update `from_environment()` to read GS env vars. Add after the existing optional value loading:
+
+```python
+        # GS pipeline optional values
+        gs_target_page = os.environ.get("CLERKBOT_GS_TARGET_PAGE", "")
+        gs_notify_raw = (os.environ.get("CLERKBOT_GS_NOTIFY_ADMINS") or "").strip().lower()
+        if gs_notify_raw not in (NotifyMode.DISABLED.value, NotifyMode.DEBUG.value, NotifyMode.ENABLED.value):
+            gs_notify_raw = NotifyMode.DISABLED.value
+        gs_notify_mode = NotifyMode(gs_notify_raw)
+        gs_dryrun_page = os.environ.get("CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE", "")
+```
+
+Add these to the `cls(...)` constructor call:
+
+```python
+            gs_target_page=gs_target_page,
+            gs_notify_mode=gs_notify_mode,
+            gs_dryrun_page=gs_dryrun_page,
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_config.py -v 2>&1 | tail -30`
+Expected: All tests PASS, both existing and new.
+
+**Step 5: Commit**
+
+```bash
+git add clerkbot/config.py tests/test_config.py
+git commit -m "Add GS pipeline fields to BotConfig (#5)"
+```
+
+---
+
+### Task 3: Update `load_topics()` to return both detectors
+
+**Files:**
+- Modify: `clerkbot/topics.py`
+- Modify: `clerkbot/__init__.py`
+- Test: `tests/test_topic.py`
+
+**Step 1: Write failing tests**
+
+Add to `tests/test_topic.py`:
+
+```python
+class TestGSTopicDetector:
+    """Tests for GS-specific TopicDetector."""
+
+    @pytest.fixture
+    def gs_detector(self):
+        """Create a TopicDetector with GS configuration."""
+        codes = ["kurd", "aa", "acas", "rusukr", "crypto", "pw", "mj", "scw&isil"]
+        page_to_code = {
+            "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+            "Wikipedia:General sanctions/Armenia and Azerbaijan": "aa",
+            "Wikipedia:General sanctions/Assyrian, Chaldean, Aramean and Syriac topics": "acas",
+            "Wikipedia:General sanctions/Russo-Ukrainian war": "rusukr",
+            "Wikipedia:General sanctions/Blockchain and cryptocurrencies": "crypto",
+            "Wikipedia:General sanctions/Professional wrestling": "pw",
+            "Wikipedia:General sanctions/Michael Jackson": "mj",
+        }
+        override_strings = {
+            "gs/kurd": "kurd",
+            "gs/aa": "aa",
+            "gs/acas": "acas",
+            "gs/rusukr": "rusukr",
+            "gs/crypto": "crypto",
+            "gs/pw": "pw",
+            "gs/mj": "mj",
+            "gs/scw": "scw&isil",
+            "gs/isil": "scw&isil",
+        }
+        return TopicDetector(codes=codes, page_to_code=page_to_code, override_strings=override_strings)
+
+    def test_gs_override_string(self, gs_detector):
+        """WP:GS/ shortcuts detected via override strings."""
+        assert gs_detector.detect("Per [[WP:GS/KURD]]") == "kurd"
+        assert gs_detector.detect("[[WP:GS/AA]]") == "aa"
+        assert gs_detector.detect("gs/acas") == "acas"
+
+    def test_gs_specific_page(self, gs_detector):
+        """Full GS page names detected via specific pages."""
+        assert gs_detector.detect("[[Wikipedia:General sanctions/Kurds and Kurdistan]]") == "kurd"
+        assert gs_detector.detect("Wikipedia:General sanctions/Armenia and Azerbaijan") == "aa"
+        assert gs_detector.detect("Per [[Wikipedia:General sanctions/Russo-Ukrainian war]]") == "rusukr"
+
+    def test_gs_bare_code(self, gs_detector):
+        """Bare GS codes detected as tokens."""
+        assert gs_detector.detect("kurd protection") == "kurd"
+        assert gs_detector.detect("RUSUKR enforcement") == "rusukr"
+
+    def test_gs_no_match(self, gs_detector):
+        assert gs_detector.detect("regular protection") == ""
+        assert gs_detector.detect("") == ""
+
+    def test_gs_priority_page_over_override(self, gs_detector):
+        """Specific page match takes priority over override string."""
+        comment = "gs/aa and Wikipedia:General sanctions/Kurds and Kurdistan"
+        assert gs_detector.detect(comment) == "kurd"
+
+    def test_dual_authority_comment(self, gs_detector):
+        """GS detector extracts GS code from dual-authority comment."""
+        assert gs_detector.detect("[[WP:CT/KURD]]/[[WP:GS/KURD]]") == "kurd"
+        assert gs_detector.detect("Arbitration enforcement - [[WP:CT/AA]]/[[WP:GS/AA]]") == "aa"
+
+
+class TestLoadTopicsGS:
+    """Tests for load_topics returning both AE and GS detectors."""
+
+    def test_load_topics_returns_tuple(self):
+        """load_topics should return (ae_detector, gs_detector) tuple."""
+        import json
+        from unittest.mock import patch, MagicMock
+        from clerkbot.topics import load_topics
+
+        config_data = {
+            "codes": ["ap", "blp"],
+            "specific_pages": {
+                "Wikipedia:Contentious topics/American politics": "ap",
+            },
+            "override_strings": {"arbind": "sa"},
+            "gs_codes": ["kurd", "aa"],
+            "gs_specific_pages": {
+                "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+            },
+            "gs_override_strings": {"gs/kurd": "kurd"},
+        }
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(config_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("clerkbot.topics.urlopen", return_value=mock_response):
+            ae_detector, gs_detector = load_topics("http://example.com/config.json", "TestAgent/1.0")
+
+        assert ae_detector.detect("WP:CT/AP") == "ap"
+        assert gs_detector.detect("gs/kurd") == "kurd"
+        # AE detector should NOT know GS codes
+        assert ae_detector.detect("gs/kurd") == ""
+        # GS detector should NOT know AE codes
+        assert gs_detector.detect("WP:CT/AP") == ""
+
+    def test_load_topics_missing_gs_keys_returns_empty_detector(self):
+        """When gs_* keys are absent, GS detector matches nothing."""
+        import json
+        from unittest.mock import patch, MagicMock
+        from clerkbot.topics import load_topics
+
+        config_data = {
+            "codes": ["ap"],
+            "specific_pages": {"Wikipedia:Contentious topics/American politics": "ap"},
+            "override_strings": {},
+        }
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(config_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("clerkbot.topics.urlopen", return_value=mock_response):
+            ae_detector, gs_detector = load_topics("http://example.com/config.json", "TestAgent/1.0")
+
+        assert ae_detector.detect("WP:CT/AP") == "ap"
+        assert gs_detector.detect("gs/kurd") == ""
+        assert gs_detector.detect("anything") == ""
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_topic.py -v -k "GS or LoadTopicsGS" 2>&1 | tail -20`
+Expected: FAIL — `load_topics` returns a single `TopicDetector`, not a tuple.
+
+**Step 3: Implement changes**
+
+Modify `load_topics()` in `clerkbot/topics.py` to return a tuple:
+
+```python
+def load_topics(url: str, user_agent: str) -> tuple:
+    """
+    Load topic detection configuration from a URL.
+
+    Args:
+        url: URL to fetch the JSON configuration from
+        user_agent: User-Agent header for the request
+
+    Returns:
+        Tuple of (ae_detector, gs_detector) TopicDetector instances
+
+    Raises:
+        ValueError: If the configuration JSON is missing required keys
+    """
+    log.info("Fetching topics configuration from %s", url)
+    request = Request(url, headers={'User-Agent': user_agent})
+    with urlopen(request) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    codes = data.get("codes", [])
+    page_to_code = data.get("specific_pages", {})
+    override_strings = data.get("override_strings", {})
+    if not codes or not page_to_code:
+        raise ValueError("Configuration JSON missing required keys 'codes' or 'specific_pages'")
+
+    ae_detector = TopicDetector(codes=codes, page_to_code=page_to_code, override_strings=override_strings)
+
+    # GS detector — gracefully handle missing keys
+    gs_codes = data.get("gs_codes", [])
+    gs_page_to_code = data.get("gs_specific_pages", {})
+    gs_override_strings = data.get("gs_override_strings", {})
+    gs_detector = TopicDetector(codes=gs_codes, page_to_code=gs_page_to_code, override_strings=gs_override_strings)
+
+    return ae_detector, gs_detector
+```
+
+**Note:** The `TopicDetector.__init__` already handles empty lists/dicts gracefully (it just won't match anything), so a GS detector built with empty config is safe.
+
+Update `clerkbot/__init__.py` — no new exports needed since `load_topics` is already exported.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_topic.py -v 2>&1 | tail -30`
+Expected: All tests PASS.
+
+**Step 5: Fix callers of `load_topics`**
+
+The call in `bot.py:main()` currently does:
+
+```python
+detector = load_topics(config.config_url, config.user_agent)
+```
+
+This will break because `load_topics` now returns a tuple. Do NOT fix it yet — Task 5 handles this as part of the `main()` refactor. But we need to make sure existing tests that import from `bot` still pass by temporarily updating the call.
+
+Actually, since `bot.py` is imported at test collection time (via `conftest.py` setting env vars, then `test_bot.py` importing from `bot`), we need to fix this now to avoid breaking the test suite. Update the single line in `bot.py:main()`:
+
+```python
+    # Old:
+    detector = load_topics(config.config_url, config.user_agent)
+    # New:
+    ae_detector, _gs_detector = load_topics(config.config_url, config.user_agent)
+```
+
+And update the call to `_process_new_log_entries` to use `ae_detector` instead of `detector`:
+
+```python
+    new_entries, unclassified_by_admin = _process_new_log_entries(
+        site, ae_detector, last_updated_dt, existing_logids
+    )
+```
+
+**Step 6: Run full test suite**
+
+Run: `venv/bin/pytest tests/ -v 2>&1 | tail -40`
+Expected: All tests PASS.
+
+**Step 7: Commit**
+
+```bash
+git add clerkbot/topics.py clerkbot/__init__.py tests/test_topic.py bot.py
+git commit -m "Update load_topics() to return both AE and GS detectors (#5)"
+```
+
+---
+
+### Task 4: Extract `_run_pipeline()` helper
+
+This is the most complex task. We refactor the existing `main()` logic into a reusable pipeline function, then wire up both AE and GS pipelines.
+
+**Files:**
+- Modify: `bot.py`
+- Test: `tests/test_bot.py`
+
+**Step 1: Write failing tests for `_run_pipeline`**
+
+Add to `tests/test_bot.py`:
+
+```python
+from unittest.mock import Mock, MagicMock, patch, call
+from clerkbot.config import BotConfig, NotifyMode
+from clerkbot.topics import TopicDetector
+from clerkbot.filters import is_arbitration_enforcement, is_community_sanction
+
+
+class TestRunPipeline:
+    """Tests for _run_pipeline helper."""
+
+    @pytest.fixture
+    def mock_site(self):
+        site = Mock()
+        site.get_token.return_value = "fake_token"
+        site.api.return_value = {"edit": {"result": "Success"}}
+        return site
+
+    @pytest.fixture
+    def ae_detector(self):
+        return TopicDetector(
+            codes=["ap", "blp"],
+            page_to_code={"Wikipedia:Contentious topics/American politics": "ap"},
+            override_strings={},
+        )
+
+    @pytest.fixture
+    def gs_detector(self):
+        return TopicDetector(
+            codes=["kurd", "aa"],
+            page_to_code={"Wikipedia:General sanctions/Kurds and Kurdistan": "kurd"},
+            override_strings={"gs/kurd": "kurd", "gs/aa": "aa"},
+        )
+
+    @pytest.fixture
+    def base_config(self):
+        return BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log",
+        )
+
+    def test_run_pipeline_returns_zero_on_success(self, mock_site, ae_detector, base_config):
+        from bot import _run_pipeline
+
+        page_text = "Last updated: 19:32, 19 August 2025 (UTC)\n{{/header}}\n{{/footer}}\n"
+        mock_page = Mock()
+        mock_page.exists = True
+        mock_page.text.return_value = page_text
+        mock_site.pages.__getitem__ = Mock(return_value=mock_page)
+        mock_page.revisions.return_value = [{"revid": 100}]
+
+        with patch("bot.enumerate_protect_logevents", return_value=[]), \
+             patch("bot.enumerate_stable_logevents", return_value=[]):
+            result = _run_pipeline(
+                site=mock_site,
+                detector=ae_detector,
+                filter_fn=is_arbitration_enforcement,
+                target_page="User:Bot/AE Log",
+                notify_mode=NotifyMode.DISABLED,
+                dryrun_page="",
+                bot_usernames=set(),
+                config=base_config,
+            )
+        assert result == 0
+
+    def test_run_pipeline_returns_2_for_missing_page(self, mock_site, ae_detector, base_config):
+        from bot import _run_pipeline
+
+        mock_page = Mock()
+        mock_page.exists = False
+        mock_site.pages.__getitem__ = Mock(return_value=mock_page)
+        mock_page.revisions.return_value = []
+
+        result = _run_pipeline(
+            site=mock_site,
+            detector=ae_detector,
+            filter_fn=is_arbitration_enforcement,
+            target_page="User:Bot/AE Log",
+            notify_mode=NotifyMode.DISABLED,
+            dryrun_page="",
+            bot_usernames=set(),
+            config=base_config,
+        )
+        assert result == 2
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_bot.py::TestRunPipeline -v 2>&1 | tail -20`
+Expected: ImportError — `_run_pipeline` doesn't exist yet.
+
+**Step 3: Implement `_run_pipeline()` by extracting from `main()`**
+
+In `bot.py`, create `_run_pipeline()` by extracting the core logic from `main()`. The function signature:
+
+```python
+def _run_pipeline(
+    site: mwclient.Site,
+    detector: "TopicDetector",
+    filter_fn,
+    target_page: str,
+    notify_mode: NotifyMode,
+    dryrun_page: str,
+    bot_usernames: Set[str],
+    config: BotConfig,
+) -> int:
+    """
+    Run one pipeline (AE or GS).
+
+    Fetches the target page, scans log events through the filter,
+    detects topics, builds updated page text, and saves.
+
+    Args:
+        site: Authenticated mwclient Site
+        detector: TopicDetector for categorizing actions
+        filter_fn: Callable(str) -> bool, the filter to apply to comments
+        target_page: Wiki page title to update
+        notify_mode: NotifyMode for admin notifications
+        dryrun_page: Page for debug notifications
+        bot_usernames: Set of bot usernames to exclude from notifications
+        config: Full BotConfig (for notification text building)
+
+    Returns:
+        0 on success, 2 on setup error, 1 on API error
+    """
+```
+
+The body is the existing logic from `main()` starting at `page, base_revid = fetch_target_page(...)` through the save and notify steps, but using `filter_fn` instead of hardcoded `is_arbitration_enforcement`.
+
+This requires modifying `_process_new_log_entries` to accept `filter_fn` as a parameter instead of hardcoding `is_arbitration_enforcement`. Change its signature:
+
+```python
+def _process_new_log_entries(
+    site: mwclient.Site,
+    detector: TopicDetector,
+    filter_fn,
+    last_updated_dt: datetime,
+    existing_logids: set,
+) -> Tuple[List[str], Dict[str, List[Tuple[int, str, str]]]]:
+```
+
+And in its body, change:
+```python
+    if not is_arbitration_enforcement(comment):
+        return
+```
+to:
+```python
+    if not filter_fn(comment):
+        return
+```
+
+Wait — that's in `_process_single_log_event`. So `_process_single_log_event` also needs `filter_fn` passed through. Update its signature:
+
+```python
+def _process_single_log_event(
+    log_event: dict,
+    detector: TopicDetector,
+    filter_fn,
+    existing_logids: set,
+    new_entries: List[str],
+    unclassified_by_admin: Dict[str, List[Tuple[int, str, str]]],
+) -> None:
+```
+
+Then update `_process_new_log_entries` to pass `filter_fn` through to `_process_single_log_event`.
+
+Then rewrite `main()` to:
+
+```python
+def main() -> int:
+    # Load topic detection data
+    try:
+        ae_detector, gs_detector = load_topics(config.config_url, config.user_agent)
+    except Exception as error:
+        log.error("Failed to load CTOP topics configuration from '%s': %s", config.config_url, error)
+        return 2
+
+    # Connect to Wikipedia and load shared data
+    site = connect_site(config)
+    bot_usernames = fetch_bot_usernames(site)
+
+    # AE pipeline (always runs)
+    ae_result = _run_pipeline(
+        site=site,
+        detector=ae_detector,
+        filter_fn=is_arbitration_enforcement,
+        target_page=config.target_page,
+        notify_mode=config.notify_mode,
+        dryrun_page=config.dryrun_page,
+        bot_usernames=bot_usernames,
+        config=config,
+    )
+    if ae_result != 0:
+        return ae_result
+
+    # GS pipeline (only if configured)
+    if config.gs_target_page:
+        gs_result = _run_pipeline(
+            site=site,
+            detector=gs_detector,
+            filter_fn=is_community_sanction,
+            target_page=config.gs_target_page,
+            notify_mode=config.gs_notify_mode,
+            dryrun_page=config.gs_dryrun_page,
+            bot_usernames=bot_usernames,
+            config=config,
+        )
+        if gs_result != 0:
+            return gs_result
+
+    return 0
+```
+
+Add `is_community_sanction` to the imports at the top of `bot.py`:
+
+```python
+from clerkbot.filters import is_arbitration_enforcement, is_community_sanction
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_bot.py -v 2>&1 | tail -40`
+Expected: All tests PASS.
+
+**Step 5: Run full test suite**
+
+Run: `venv/bin/pytest tests/ -v 2>&1 | tail -40`
+Expected: All tests PASS. Existing AE behavior is preserved.
+
+**Step 6: Commit**
+
+```bash
+git add bot.py tests/test_bot.py
+git commit -m "Extract _run_pipeline() helper and wire up GS pipeline (#5)"
+```
+
+---
+
+### Task 5: Add integration-style tests for dual-pipeline behavior
+
+**Files:**
+- Modify: `tests/test_bot.py`
+
+**Step 1: Write tests for dual-pipeline scenarios**
+
+Add to `tests/test_bot.py`:
+
+```python
+class TestDualPipeline:
+    """Tests for AE + GS dual pipeline behavior."""
+
+    def test_gs_pipeline_skipped_when_not_configured(self):
+        """GS pipeline should not run when gs_target_page is empty."""
+        config = BotConfig(
+            username="test", password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="",
+        )
+        assert config.gs_target_page == ""
+        # This is tested implicitly by main() — gs_target_page == "" means
+        # the GS _run_pipeline call is skipped entirely
+
+    def test_ae_filter_does_not_match_gs_only(self):
+        """AE filter should not match GS-only comments."""
+        assert not is_arbitration_enforcement("Per [[WP:GS/KURD]]")
+        assert not is_arbitration_enforcement("[[Wikipedia:General sanctions/Armenia and Azerbaijan]]")
+        assert not is_arbitration_enforcement("community sanction enforcement")
+
+    def test_gs_filter_does_not_match_ae_only(self):
+        """GS filter should not match AE-only comments."""
+        assert not is_community_sanction("Per arbitration enforcement WP:CT/BLP")
+        assert not is_community_sanction("CTOP protection")
+        assert not is_community_sanction("[[WP:AE]] action")
+
+    def test_both_filters_match_dual_authority(self):
+        """Both filters should match dual-authority comments."""
+        dual = "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]"
+        assert is_arbitration_enforcement(dual)
+        assert is_community_sanction(dual)
+
+    def test_dedup_via_logid(self):
+        """Existing logid extraction works for dedup across pipelines."""
+        from bot import extract_existing_logids
+        text = "{{User:ClerkBot/AE entry|logid=12345|admin=A}}\n{{User:ClerkBot/AE entry|logid=67890|admin=B}}"
+        logids = extract_existing_logids(text)
+        assert 12345 in logids
+        assert 67890 in logids
+```
+
+**Step 2: Run tests**
+
+Run: `venv/bin/pytest tests/test_bot.py::TestDualPipeline -v 2>&1 | tail -20`
+Expected: All PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_bot.py
+git commit -m "Add dual-pipeline integration tests (#5)"
+```
+
+---
+
+### Task 6: Update `__init__.py` exports and docstrings
+
+**Files:**
+- Modify: `clerkbot/__init__.py`
+- Modify: `bot.py` (module docstring)
+
+**Step 1: Update `clerkbot/__init__.py`**
+
+Add `GS_TRIGGERS` and `is_community_sanction` to the imports and `__all__` list if not already done in Task 1.
+
+**Step 2: Update `bot.py` module docstring**
+
+Add the new GS env vars to the docstring at the top of `bot.py`:
+
+```
+  CLERKBOT_GS_TARGET_PAGE        Optional. Target page for GS entries (empty = GS disabled)
+  CLERKBOT_GS_NOTIFY_ADMINS      Optional. Notification mode for GS pipeline ("false", "debug", "true")
+  CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE  Optional. Debug notification page for GS
+```
+
+**Step 3: Run full test suite**
+
+Run: `venv/bin/pytest tests/ -v 2>&1 | tail -40`
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add clerkbot/__init__.py bot.py
+git commit -m "Update exports and docstrings for GS pipeline (#5)"
+```
+
+---
+
+### Task 7: Final verification and cleanup
+
+**Step 1: Run full test suite with coverage**
+
+Run: `venv/bin/pytest tests/ -v --cov=clerkbot --cov=bot --cov-report=term-missing 2>&1 | tail -50`
+Expected: All tests PASS. New code has reasonable coverage.
+
+**Step 2: Verify no regressions by checking existing AE test counts**
+
+Run: `venv/bin/pytest tests/ -v 2>&1 | grep -c PASSED`
+Expected: Test count increased from before (new GS tests added, no tests removed).
+
+**Step 3: Clean up pywikibot files**
+
+Remove the pywikibot credentials and venv artifacts that were added for research:
+```bash
+rm -f user-config.py user-password.py
+rm -rf venv/
+```
+
+**Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "Clean up research artifacts (#5)"
+```
+
+**Step 5: Push and create PR**
+
+```bash
+git checkout -b gs-pipeline
+git push -u origin gs-pipeline
+gh pr create --title "Add community sanctions (GS) pipeline" --body "$(cat <<'EOF'
+## Summary
+- Adds `is_community_sanction()` filter for detecting community general sanction protection actions
+- Adds GS fields to `BotConfig` (`CLERKBOT_GS_TARGET_PAGE`, `CLERKBOT_GS_NOTIFY_ADMINS`, etc.)
+- Updates `load_topics()` to return both AE and GS `TopicDetector` instances from merged on-wiki config
+- Extracts `_run_pipeline()` helper from `main()` to avoid duplication
+- Wires up GS pipeline to run after AE pipeline when configured
+- GS notifications default to disabled (see #19 for future template support)
+
+Closes #5
+
+## Test plan
+- [ ] All existing AE tests pass unchanged
+- [ ] New GS filter tests verify trigger matching and no false positives
+- [ ] New config tests verify GS env var loading and defaults
+- [ ] New topic detector tests verify GS-specific detection
+- [ ] Dual-pipeline tests verify dedup and filter independence
+- [ ] Manual test with `CLERKBOT_GS_TARGET_PAGE` set to a test page
+EOF
+)"
+```

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -490,3 +490,45 @@ class TestRunPipeline:
             config=base_config,
         )
         assert result == 2
+
+
+class TestDualPipeline:
+    """Tests for AE + GS dual pipeline behavior."""
+
+    def test_gs_pipeline_skipped_when_not_configured(self):
+        """GS pipeline should not run when gs_target_page is empty."""
+        from clerkbot.config import BotConfig, NotifyMode
+        config = BotConfig(
+            username="test", password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="",
+        )
+        assert config.gs_target_page == ""
+        # This is tested implicitly by main() — gs_target_page == "" means
+        # the GS _run_pipeline call is skipped entirely
+
+    def test_ae_filter_does_not_match_gs_only(self):
+        """AE filter should not match GS-only comments."""
+        assert not is_arbitration_enforcement("Per [[WP:GS/KURD]]")
+        assert not is_arbitration_enforcement("[[Wikipedia:General sanctions/Armenia and Azerbaijan]]")
+        assert not is_arbitration_enforcement("community sanction enforcement")
+
+    def test_gs_filter_does_not_match_ae_only(self):
+        """GS filter should not match AE-only comments."""
+        assert not is_community_sanction("Per arbitration enforcement WP:CT/BLP")
+        assert not is_community_sanction("CTOP protection")
+        assert not is_community_sanction("[[WP:AE]] action")
+
+    def test_both_filters_match_dual_authority(self):
+        """Both filters should match dual-authority comments."""
+        dual = "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]"
+        assert is_arbitration_enforcement(dual)
+        assert is_community_sanction(dual)
+
+    def test_dedup_via_logid(self):
+        """Existing logid extraction works for dedup across pipelines."""
+        from bot import extract_existing_logids
+        text = "{{User:ClerkBot/AE entry|logid=12345|admin=A}}\n{{User:ClerkBot/AE entry|logid=67890|admin=B}}"
+        logids = extract_existing_logids(text)
+        assert 12345 in logids
+        assert 67890 in logids

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -12,7 +12,7 @@ from bot import (
     _get_event_sort_key,
 )
 from clerkbot.entries import build_action_string
-from clerkbot.filters import is_arbitration_enforcement
+from clerkbot.filters import is_arbitration_enforcement, is_community_sanction
 from clerkbot.timestamp import (
     parse_mediawiki_sig_timestamp,
     to_mediawiki_sig_timestamp,
@@ -402,3 +402,91 @@ class TestEditConflictHandling:
                 new_entries=["entry1"],
                 base_revid=12345
             )
+
+
+class TestRunPipeline:
+    """Tests for _run_pipeline helper."""
+
+    @pytest.fixture
+    def mock_site(self):
+        from unittest.mock import Mock
+        site = Mock()
+        site.get_token.return_value = "fake_token"
+        site.api.return_value = {"edit": {"result": "Success"}}
+        return site
+
+    @pytest.fixture
+    def ae_detector(self):
+        from clerkbot.topics import TopicDetector
+        return TopicDetector(
+            codes=["ap", "blp"],
+            page_to_code={"Wikipedia:Contentious topics/American politics": "ap"},
+            override_strings={},
+        )
+
+    @pytest.fixture
+    def gs_detector(self):
+        from clerkbot.topics import TopicDetector
+        return TopicDetector(
+            codes=["kurd", "aa"],
+            page_to_code={"Wikipedia:General sanctions/Kurds and Kurdistan": "kurd"},
+            override_strings={"gs/kurd": "kurd", "gs/aa": "aa"},
+        )
+
+    @pytest.fixture
+    def base_config(self):
+        from clerkbot.config import BotConfig
+        return BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log",
+        )
+
+    def test_run_pipeline_returns_zero_on_success(self, mock_site, ae_detector, base_config):
+        from unittest.mock import Mock, patch
+        from bot import _run_pipeline
+        from clerkbot.config import NotifyMode
+
+        page_text = "Last updated: 19:32, 19 August 2025 (UTC)\n{{/header}}\n{{/footer}}\n"
+        mock_page = Mock()
+        mock_page.exists = True
+        mock_page.text.return_value = page_text
+        mock_site.pages.__getitem__ = Mock(return_value=mock_page)
+        mock_page.revisions.return_value = [{"revid": 100}]
+
+        with patch("bot.enumerate_protect_logevents", return_value=[]), \
+             patch("bot.enumerate_stable_logevents", return_value=[]):
+            result = _run_pipeline(
+                site=mock_site,
+                detector=ae_detector,
+                filter_fn=is_arbitration_enforcement,
+                target_page="User:Bot/AE Log",
+                notify_mode=NotifyMode.DISABLED,
+                dryrun_page="",
+                bot_usernames=set(),
+                config=base_config,
+            )
+        assert result == 0
+
+    def test_run_pipeline_returns_2_for_missing_page(self, mock_site, ae_detector, base_config):
+        from unittest.mock import Mock
+        from bot import _run_pipeline
+        from clerkbot.config import NotifyMode
+
+        mock_page = Mock()
+        mock_page.exists = False
+        mock_site.pages.__getitem__ = Mock(return_value=mock_page)
+        mock_page.revisions.return_value = []
+
+        result = _run_pipeline(
+            site=mock_site,
+            detector=ae_detector,
+            filter_fn=is_arbitration_enforcement,
+            target_page="User:Bot/AE Log",
+            notify_mode=NotifyMode.DISABLED,
+            dryrun_page="",
+            bot_usernames=set(),
+            config=base_config,
+        )
+        assert result == 2

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -526,18 +526,6 @@ class TestRunPipeline:
 class TestDualPipeline:
     """Tests for AE + GS dual pipeline behavior."""
 
-    def test_gs_pipeline_skipped_when_not_configured(self):
-        """GS pipeline should not run when gs_target_page is empty."""
-        from clerkbot.config import BotConfig, NotifyMode
-        config = BotConfig(
-            username="test", password="pass",
-            target_page="User:Bot/AE Log",
-            gs_target_page="",
-        )
-        assert config.gs_target_page == ""
-        # This is tested implicitly by main() — gs_target_page == "" means
-        # the GS _run_pipeline call is skipped entirely
-
     def test_ae_filter_does_not_match_gs_only(self):
         """AE filter should not match GS-only comments."""
         assert not is_arbitration_enforcement("Per [[WP:GS/KURD]]")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -350,6 +350,56 @@ class TestBuildNotificationText:
         assert result.count("* [[Special:Redirect/logid/") == 2
 
 
+class TestNotifyAdminsParams:
+    """Tests for _notify_admins using pipeline-specific parameters."""
+
+    def test_gs_params_forwarded(self):
+        """GS-specific notify_mode, dryrun_page, target_page are used."""
+        from unittest.mock import Mock
+        from bot import _notify_admins
+        from clerkbot.config import NotifyMode
+
+        mock_site = Mock()
+        mock_site.api.return_value = {"edit": {"result": "Success"}}
+
+        unclassified = {"AdminX": [(999, "12:00, 1 January 2026", "GS Page")]}
+        _notify_admins(
+            site=mock_site,
+            unclassified_by_admin=unclassified,
+            token="fake",
+            bot_usernames=set(),
+            notify_mode=NotifyMode.DEBUG,
+            dryrun_page="User:Bot/GS dryrun",
+            target_page="User:Bot/GS Log",
+        )
+
+        mock_site.api.assert_called_once()
+        call_kwargs = mock_site.api.call_args[1]
+        # Should post to the GS dryrun page, not the AE one
+        assert call_kwargs["title"] == "User:Bot/GS dryrun"
+        # Notification text should reference the GS target page
+        assert "User:Bot/GS Log" in call_kwargs["appendtext"]
+
+    def test_disabled_mode_does_not_post(self):
+        """DISABLED notify_mode should not make any API calls."""
+        from unittest.mock import Mock
+        from bot import _notify_admins
+        from clerkbot.config import NotifyMode
+
+        mock_site = Mock()
+        unclassified = {"AdminX": [(999, "12:00, 1 January 2026", "Page")]}
+        _notify_admins(
+            site=mock_site,
+            unclassified_by_admin=unclassified,
+            token="fake",
+            bot_usernames=set(),
+            notify_mode=NotifyMode.DISABLED,
+            dryrun_page="",
+            target_page="User:Bot/Log",
+        )
+        mock_site.api.assert_not_called()
+
+
 class TestEditConflictHandling:
     """Tests for edit conflict detection and handling."""
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -474,26 +474,7 @@ class TestRunPipeline:
             override_strings={},
         )
 
-    @pytest.fixture
-    def gs_detector(self):
-        from clerkbot.topics import TopicDetector
-        return TopicDetector(
-            codes=["kurd", "aa"],
-            page_to_code={"Wikipedia:General sanctions/Kurds and Kurdistan": "kurd"},
-            override_strings={"gs/kurd": "kurd", "gs/aa": "aa"},
-        )
-
-    @pytest.fixture
-    def base_config(self):
-        from clerkbot.config import BotConfig
-        return BotConfig(
-            username="test",
-            password="pass",
-            target_page="User:Bot/AE Log",
-            gs_target_page="User:Bot/GS Log",
-        )
-
-    def test_run_pipeline_returns_zero_on_success(self, mock_site, ae_detector, base_config):
+    def test_run_pipeline_returns_zero_on_success(self, mock_site, ae_detector):
         from unittest.mock import Mock, patch
         from bot import _run_pipeline
         from clerkbot.config import NotifyMode
@@ -515,11 +496,11 @@ class TestRunPipeline:
                 notify_mode=NotifyMode.DISABLED,
                 dryrun_page="",
                 bot_usernames=set(),
-                config=base_config,
+                pipeline_label="AE",
             )
         assert result == 0
 
-    def test_run_pipeline_returns_2_for_missing_page(self, mock_site, ae_detector, base_config):
+    def test_run_pipeline_returns_2_for_missing_page(self, mock_site, ae_detector):
         from unittest.mock import Mock
         from bot import _run_pipeline
         from clerkbot.config import NotifyMode
@@ -537,7 +518,7 @@ class TestRunPipeline:
             notify_mode=NotifyMode.DISABLED,
             dryrun_page="",
             bot_usernames=set(),
-            config=base_config,
+            pipeline_label="AE",
         )
         assert result == 2
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,3 +160,87 @@ class TestBotConfig:
         """Test that log level is converted to uppercase."""
         config = BotConfig.from_environment()
         assert config.log_level == "WARNING"
+
+
+class TestBotConfigGS:
+    """Tests for GS-related configuration fields."""
+
+    def test_gs_defaults_when_not_set(self):
+        """GS pipeline defaults to disabled."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/Log"
+        )
+        assert config.gs_target_page == ""
+        assert config.gs_notify_mode == NotifyMode.DISABLED
+        assert config.gs_dryrun_page == ""
+
+    def test_gs_dryrun_page_computed(self):
+        """gs_dryrun_page is computed from gs_target_page if not set."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log"
+        )
+        assert config.gs_dryrun_page == "User:Bot/GS Log/notifications_dryrun"
+
+    def test_gs_dryrun_page_explicit(self):
+        """Explicit gs_dryrun_page is preserved."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/AE Log",
+            gs_target_page="User:Bot/GS Log",
+            gs_dryrun_page="User:Bot/GS Dryrun"
+        )
+        assert config.gs_dryrun_page == "User:Bot/GS Dryrun"
+
+    def test_gs_dryrun_page_empty_when_gs_disabled(self):
+        """gs_dryrun_page stays empty when gs_target_page is empty."""
+        config = BotConfig(
+            username="test",
+            password="pass",
+            target_page="User:Bot/Log",
+            gs_target_page=""
+        )
+        assert config.gs_dryrun_page == ""
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+    }, clear=True)
+    def test_from_environment_gs_disabled_by_default(self):
+        """GS pipeline is disabled when env vars are not set."""
+        config = BotConfig.from_environment()
+        assert config.gs_target_page == ""
+        assert config.gs_notify_mode == NotifyMode.DISABLED
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+        "CLERKBOT_GS_TARGET_PAGE": "User:TestBot/GS log",
+        "CLERKBOT_GS_NOTIFY_ADMINS": "debug",
+        "CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE": "User:TestBot/GS dryrun",
+    }, clear=True)
+    def test_from_environment_gs_full(self):
+        """GS configuration is loaded from environment."""
+        config = BotConfig.from_environment()
+        assert config.gs_target_page == "User:TestBot/GS log"
+        assert config.gs_notify_mode == NotifyMode.DEBUG
+        assert config.gs_dryrun_page == "User:TestBot/GS dryrun"
+
+    @patch.dict(os.environ, {
+        "CLERKBOT_USERNAME": "TestBot",
+        "CLERKBOT_PASSWORD": "secret123",
+        "CLERKBOT_TARGET_PAGE": "User:TestBot/AE log",
+        "CLERKBOT_GS_TARGET_PAGE": "User:TestBot/GS log",
+        "CLERKBOT_GS_NOTIFY_ADMINS": "invalid",
+    }, clear=True)
+    def test_from_environment_gs_invalid_notify_defaults_disabled(self):
+        """Invalid GS notify mode defaults to DISABLED (not DEBUG like AE)."""
+        config = BotConfig.from_environment()
+        assert config.gs_notify_mode == NotifyMode.DISABLED

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -220,3 +220,107 @@ class TestIsCommunityGS:
     def test_special_characters_in_comment(self):
         assert is_community_sanction("[[WP:GS/KURD|community sanctions]]")
         assert is_community_sanction("Protection: [[Wikipedia:General sanctions/Weather events]]")
+
+
+class TestRealWorldComments:
+    """
+    Tests against real edit summaries from Wikipedia protection logs.
+    Source: 5000 recent protect log events queried 2026-03-26.
+    """
+
+    # --- AE-only comments: match AE, NOT GS ---
+
+    @pytest.mark.parametrize("comment", [
+        "Violations of the [[WP:BLP|biographies of living persons policy]] - [[WP:CT/BLP]]; requested at [[WP:RfPP]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcment: [[WP:CT/GG]]; requested at [[WP:RfPP]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/IMH]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcement: [[WP:CT/SA]]; requested at [[WP:RfPP]]",
+        "[[WP:CTOP|Contentious topic]] restriction: [[WP:BLPCT]]",
+        "[[WP:30/500|Arbitration enforcement]] [[WP:CT/IMH]]",
+        "[[WP:30/500|Arbitration enforcement]], [[WP:CT/SA]], edit warring and other disruptive editing from TAs and autoconfirmed",
+    ])
+    def test_ae_only_matches_ae(self, comment):
+        assert is_arbitration_enforcement(comment)
+
+    @pytest.mark.parametrize("comment", [
+        "Violations of the [[WP:BLP|biographies of living persons policy]] - [[WP:CT/BLP]]; requested at [[WP:RfPP]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcment: [[WP:CT/GG]]; requested at [[WP:RfPP]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/IMH]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcement: [[WP:CT/SA]]; requested at [[WP:RfPP]]",
+        "[[WP:CTOP|Contentious topic]] restriction: [[WP:BLPCT]]",
+        "[[WP:30/500|Arbitration enforcement]] [[WP:CT/IMH]]",
+    ])
+    def test_ae_only_does_not_match_gs(self, comment):
+        assert not is_community_sanction(comment)
+
+    # --- GS-only comments: match GS, NOT AE ---
+
+    @pytest.mark.parametrize("comment", [
+        "Per [[WP:GS/KURD]]",
+        "[[Wikipedia:General sanctions/Armenia and Azerbaijan]]",
+        "[[WP:GS#Community sanctions|Community sanctions enforcement]]: WP:GS/KURD",
+        "[[WP:GS#Community sanctions|Community sanctions enforcement]]: per RFPP and [[WP:GS/PAGEANT]]",
+        "Enforcement for [[WP:GS/PW]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - [[WP:GS/MJ]]; requested at [[WP:RfPP]]",
+        "[[WP:GS/RUSUKR]]",
+        "Per [[Wikipedia:General sanctions/Russo-Ukrainian war]]",
+        "Per [[Wikipedia:General sanctions/Kurds and Kurdistan]]",
+        "[[WP:GS#Community sanctions|Community sanctions enforcement]]: per [[WP:GS/ACAS]]",
+    ])
+    def test_gs_only_matches_gs(self, comment):
+        assert is_community_sanction(comment)
+
+    @pytest.mark.parametrize("comment", [
+        "Per [[WP:GS/KURD]]",
+        "[[Wikipedia:General sanctions/Armenia and Azerbaijan]]",
+        "Enforcement for [[WP:GS/PW]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]] - [[WP:GS/MJ]]; requested at [[WP:RfPP]]",
+        "[[WP:GS/RUSUKR]]",
+        "Per [[Wikipedia:General sanctions/Russo-Ukrainian war]]",
+    ])
+    def test_gs_only_does_not_match_ae(self, comment):
+        assert not is_arbitration_enforcement(comment)
+
+    # --- Dual-authority comments: match BOTH ---
+
+    @pytest.mark.parametrize("comment", [
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]; requested at [[WP:RfPP]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/AA]]/[[WP:GS/AA]]; requested at [[WP:RfPP]]",
+        "Persistent [[WP:Vandalism|vandalism]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]; requested at [[WP:RfPP]]",
+        "[[WP:CT/A-I]], [[WP:GS/KURD]]",
+    ])
+    def test_dual_matches_both_ae(self, comment):
+        assert is_arbitration_enforcement(comment)
+
+    @pytest.mark.parametrize("comment", [
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]; requested at [[WP:RfPP]]",
+        "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/AA]]/[[WP:GS/AA]]; requested at [[WP:RfPP]]",
+        "Persistent [[WP:Vandalism|vandalism]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]; requested at [[WP:RfPP]]",
+        "[[WP:CT/A-I]], [[WP:GS/KURD]]",
+    ])
+    def test_dual_matches_both_gs(self, comment):
+        assert is_community_sanction(comment)
+
+    # --- Neither: should match nothing ---
+
+    @pytest.mark.parametrize("comment", [
+        "[[WP:SALT|Repeatedly recreated]] by socks",
+        "[[WP:SALT|Repeatedly recreated]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]]; requested at [[WP:RfPP]]",
+        "Restoring protection by [[User:Pathoschild|Pathoschild]]",
+        "",
+    ])
+    def test_neither_matches_ae(self, comment):
+        assert not is_arbitration_enforcement(comment)
+
+    @pytest.mark.parametrize("comment", [
+        "[[WP:SALT|Repeatedly recreated]] by socks",
+        "[[WP:SALT|Repeatedly recreated]]",
+        "Persistent [[WP:Disruptive editing|disruptive editing]]; requested at [[WP:RfPP]]",
+        "Restoring protection by [[User:Pathoschild|Pathoschild]]",
+        "",
+    ])
+    def test_neither_matches_gs(self, comment):
+        assert not is_community_sanction(comment)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -177,6 +177,10 @@ class TestIsCommunityGS:
     def test_community_designated_phrase(self):
         assert is_community_sanction("community-designated contentious topic")
 
+    def test_wp_gs_bare_with_space(self):
+        assert is_community_sanction("Per WP:GS enforcement")
+        assert is_community_sanction("WP:GS applies here")
+
     def test_case_insensitive(self):
         assert is_community_sanction("WP:GS/KURD")
         assert is_community_sanction("wp:gs/kurd")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,7 @@
 import pytest
 
 from clerkbot.filters import AE_TRIGGERS, is_arbitration_enforcement
+from clerkbot.filters import GS_TRIGGERS, is_community_sanction
 
 
 class TestAETriggers:
@@ -124,3 +125,94 @@ class TestIsArbitrationEnforcement:
         assert is_arbitration_enforcement("[[WP:CTOP/AP|contentious topic]]")
         assert is_arbitration_enforcement("Protection: [[arbitration]]")
         assert is_arbitration_enforcement("See {{ct/blp}} for details")
+
+
+class TestGSTriggers:
+    """Tests for GS_TRIGGERS constant."""
+
+    def test_triggers_list_not_empty(self):
+        assert len(GS_TRIGGERS) > 0
+
+    def test_triggers_are_lowercase(self):
+        for trigger in GS_TRIGGERS:
+            assert trigger == trigger.lower(), f"Trigger '{trigger}' is not lowercase"
+
+    def test_triggers_are_strings(self):
+        for trigger in GS_TRIGGERS:
+            assert isinstance(trigger, str)
+
+    def test_expected_triggers_present(self):
+        expected = ["general sanction", "wp:gs/", "wikipedia:general sanctions/"]
+        for trigger in expected:
+            assert trigger in GS_TRIGGERS, f"Expected trigger '{trigger}' not found"
+
+
+class TestIsCommunityGS:
+    """Tests for community sanction detection."""
+
+    def test_wp_gs_slash_trigger(self):
+        assert is_community_sanction("Per [[WP:GS/KURD]]")
+        assert is_community_sanction("[[WP:GS/AA]]")
+        assert is_community_sanction("wp:gs/acas")
+
+    def test_wikipedia_gs_slash_trigger(self):
+        assert is_community_sanction("[[Wikipedia:GS/KURD]]")
+
+    def test_wp_gs_bracket_trigger(self):
+        assert is_community_sanction("[[WP:GS]]")
+        assert is_community_sanction("[[WP:GS|community sanctions]]")
+
+    def test_full_page_name_trigger(self):
+        assert is_community_sanction("[[Wikipedia:General sanctions/Kurds and Kurdistan]]")
+        assert is_community_sanction("Wikipedia:General sanctions/Armenia and Azerbaijan")
+
+    def test_general_sanction_phrase(self):
+        assert is_community_sanction("Per general sanctions")
+        assert is_community_sanction("GENERAL SANCTION applies")
+
+    def test_community_sanction_phrase(self):
+        assert is_community_sanction("community sanction enforcement")
+        assert is_community_sanction("Community Sanction")
+
+    def test_community_designated_phrase(self):
+        assert is_community_sanction("community-designated contentious topic")
+
+    def test_case_insensitive(self):
+        assert is_community_sanction("WP:GS/KURD")
+        assert is_community_sanction("wp:gs/kurd")
+        assert is_community_sanction("Wp:Gs/Kurd")
+
+    def test_no_match(self):
+        assert not is_community_sanction("Regular vandalism protection")
+        assert not is_community_sanction("Requested at RFPP")
+        assert not is_community_sanction("")
+        assert not is_community_sanction(None)
+        assert not is_community_sanction("   ")
+
+    def test_no_false_positive_from_substrings(self):
+        """Ensure common words containing trigger substrings don't match."""
+        assert not is_community_sanction("Repeatedly recreated")
+        assert not is_community_sanction("persistent disruption")
+
+    def test_ae_only_comment_does_not_match(self):
+        """AE-only comments should not match the GS filter."""
+        assert not is_community_sanction("Per arbitration enforcement WP:CT/BLP")
+        assert not is_community_sanction("CTOP protection")
+
+    def test_dual_authority_comment_matches(self):
+        """Comments citing both AE and GS should match GS filter."""
+        assert is_community_sanction("[[WP:CT/KURD]]/[[WP:GS/KURD]]")
+        assert is_community_sanction("Arbitration enforcement - [[WP:CT/AA]]/[[WP:GS/AA]]")
+
+    def test_real_world_comments(self):
+        """Test against real edit summaries observed in the wild."""
+        assert is_community_sanction("Per [[WP:GS/KURD]]")
+        assert is_community_sanction("[[Wikipedia:General sanctions/Armenia and Azerbaijan]]")
+        assert is_community_sanction("[[WP:GS#Community sanctions|Community sanctions enforcement]]: WP:GS/KURD")
+        assert is_community_sanction("Enforcement for [[WP:GS/PW]]")
+        assert is_community_sanction("Persistent disruptive editing - [[WP:GS/MJ]]; requested at [[WP:RfPP]]")
+        assert is_community_sanction("[[WP:GS/RUSUKR]]")
+
+    def test_special_characters_in_comment(self):
+        assert is_community_sanction("[[WP:GS/KURD|community sanctions]]")
+        assert is_community_sanction("Protection: [[Wikipedia:General sanctions/Weather events]]")

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -119,3 +119,126 @@ class TestTopicDetector:
         # Shortcut should win
         comment = "WP:CT/AP also mentions BLP"
         assert detector.detect(comment) == "ap"
+
+
+class TestGSTopicDetector:
+    """Tests for GS-specific TopicDetector."""
+
+    @pytest.fixture
+    def gs_detector(self):
+        """Create a TopicDetector with GS configuration."""
+        codes = ["kurd", "aa", "acas", "rusukr", "crypto", "pw", "mj", "scw&isil"]
+        page_to_code = {
+            "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+            "Wikipedia:General sanctions/Armenia and Azerbaijan": "aa",
+            "Wikipedia:General sanctions/Assyrian, Chaldean, Aramean and Syriac topics": "acas",
+            "Wikipedia:General sanctions/Russo-Ukrainian war": "rusukr",
+            "Wikipedia:General sanctions/Blockchain and cryptocurrencies": "crypto",
+            "Wikipedia:General sanctions/Professional wrestling": "pw",
+            "Wikipedia:General sanctions/Michael Jackson": "mj",
+        }
+        override_strings = {
+            "gs/kurd": "kurd",
+            "gs/aa": "aa",
+            "gs/acas": "acas",
+            "gs/rusukr": "rusukr",
+            "gs/crypto": "crypto",
+            "gs/pw": "pw",
+            "gs/mj": "mj",
+            "gs/scw": "scw&isil",
+            "gs/isil": "scw&isil",
+        }
+        return TopicDetector(codes=codes, page_to_code=page_to_code, override_strings=override_strings)
+
+    def test_gs_override_string(self, gs_detector):
+        """WP:GS/ shortcuts detected via override strings."""
+        assert gs_detector.detect("Per [[WP:GS/KURD]]") == "kurd"
+        assert gs_detector.detect("[[WP:GS/AA]]") == "aa"
+        assert gs_detector.detect("gs/acas") == "acas"
+
+    def test_gs_specific_page(self, gs_detector):
+        """Full GS page names detected via specific pages."""
+        assert gs_detector.detect("[[Wikipedia:General sanctions/Kurds and Kurdistan]]") == "kurd"
+        assert gs_detector.detect("Wikipedia:General sanctions/Armenia and Azerbaijan") == "aa"
+        assert gs_detector.detect("Per [[Wikipedia:General sanctions/Russo-Ukrainian war]]") == "rusukr"
+
+    def test_gs_bare_code(self, gs_detector):
+        """Bare GS codes detected as tokens."""
+        assert gs_detector.detect("kurd protection") == "kurd"
+        assert gs_detector.detect("RUSUKR enforcement") == "rusukr"
+
+    def test_gs_no_match(self, gs_detector):
+        assert gs_detector.detect("regular protection") == ""
+        assert gs_detector.detect("") == ""
+
+    def test_gs_priority_page_over_override(self, gs_detector):
+        """Specific page match takes priority over override string."""
+        comment = "gs/aa and Wikipedia:General sanctions/Kurds and Kurdistan"
+        assert gs_detector.detect(comment) == "kurd"
+
+    def test_dual_authority_comment(self, gs_detector):
+        """GS detector extracts GS code from dual-authority comment."""
+        assert gs_detector.detect("[[WP:CT/KURD]]/[[WP:GS/KURD]]") == "kurd"
+        assert gs_detector.detect("Arbitration enforcement - [[WP:CT/AA]]/[[WP:GS/AA]]") == "aa"
+
+
+class TestLoadTopicsGS:
+    """Tests for load_topics returning both AE and GS detectors."""
+
+    def test_load_topics_returns_tuple(self):
+        """load_topics should return (ae_detector, gs_detector) tuple."""
+        import json
+        from unittest.mock import patch, MagicMock
+        from clerkbot.topics import load_topics
+
+        config_data = {
+            "codes": ["ap", "blp"],
+            "specific_pages": {
+                "Wikipedia:Contentious topics/American politics": "ap",
+            },
+            "override_strings": {"arbind": "sa"},
+            "gs_codes": ["kurd", "aa"],
+            "gs_specific_pages": {
+                "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+            },
+            "gs_override_strings": {"gs/kurd": "kurd"},
+        }
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(config_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("clerkbot.topics.urlopen", return_value=mock_response):
+            ae_detector, gs_detector = load_topics("http://example.com/config.json", "TestAgent/1.0")
+
+        assert ae_detector.detect("WP:CT/AP") == "ap"
+        assert gs_detector.detect("gs/kurd") == "kurd"
+        # AE detector should NOT know GS codes
+        assert ae_detector.detect("gs/kurd") == ""
+        # GS detector should NOT know AE codes
+        assert gs_detector.detect("WP:CT/AP") == ""
+
+    def test_load_topics_missing_gs_keys_returns_empty_detector(self):
+        """When gs_* keys are absent, GS detector matches nothing."""
+        import json
+        from unittest.mock import patch, MagicMock
+        from clerkbot.topics import load_topics
+
+        config_data = {
+            "codes": ["ap"],
+            "specific_pages": {"Wikipedia:Contentious topics/American politics": "ap"},
+            "override_strings": {},
+        }
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(config_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("clerkbot.topics.urlopen", return_value=mock_response):
+            ae_detector, gs_detector = load_topics("http://example.com/config.json", "TestAgent/1.0")
+
+        assert ae_detector.detect("WP:CT/AP") == "ap"
+        assert gs_detector.detect("gs/kurd") == ""
+        assert gs_detector.detect("anything") == ""

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -242,3 +242,161 @@ class TestLoadTopicsGS:
         assert ae_detector.detect("WP:CT/AP") == "ap"
         assert gs_detector.detect("gs/kurd") == ""
         assert gs_detector.detect("anything") == ""
+
+
+class TestRealWorldTopicDetection:
+    """
+    Tests topic detection against real edit summaries from Wikipedia.
+    Source: 5000 recent protect log events queried 2026-03-26.
+    """
+
+    @pytest.fixture
+    def ae_detector(self):
+        """AE detector with production-like config."""
+        return TopicDetector(
+            codes=["a-a", "a-i", "ap", "blp", "cam", "ee", "gg", "gmo",
+                   "horn", "irp", "kurd", "mos", "ps", "r-i", "sa", "tt",
+                   "imh", "sasg", "covid", "ab", "at", "cid", "rne", "ya"],
+            page_to_code={
+                "Wikipedia:Contentious topics/Armenia-Azerbaijan": "a-a",
+                "Wikipedia:Contentious topics/Arab\u2013Israeli conflict": "a-i",
+                "Wikipedia:Contentious topics/American politics": "ap",
+                "Wikipedia:Contentious topics/Biographies of Living Persons": "blp",
+                "Wikipedia:Contentious topics/South Asia": "sa",
+                "Wikipedia:Contentious topics/Gender and sexuality": "gg",
+                "Wikipedia:Contentious topics/Kurds and Kurdistan": "kurd",
+            },
+            override_strings={
+                "arbind": "sa",
+                "pia": "a-i",
+                "balkans": "ee",
+                "arbimh": "imh",
+                "blpct": "blp",
+                "blpds": "blp",
+            },
+        )
+
+    @pytest.fixture
+    def gs_detector(self):
+        """GS detector with production-like config."""
+        return TopicDetector(
+            codes=["scw&isil", "crypto", "pw", "mj", "pageant", "rusukr",
+                   "uyghur", "aa", "kurd", "acas", "we"],
+            page_to_code={
+                "Wikipedia:General sanctions/Kurds and Kurdistan": "kurd",
+                "Wikipedia:General sanctions/Armenia and Azerbaijan": "aa",
+                "Wikipedia:General sanctions/Russo-Ukrainian war": "rusukr",
+                "Wikipedia:General sanctions/Professional wrestling": "pw",
+                "Wikipedia:General sanctions/Michael Jackson": "mj",
+                "Wikipedia:General sanctions/Assyrian, Chaldean, Aramean and Syriac topics": "acas",
+                "Wikipedia:General sanctions/Weather events": "we",
+            },
+            override_strings={
+                "gs/kurd": "kurd",
+                "gs/aa": "aa",
+                "gs/acas": "acas",
+                "gs/rusukr": "rusukr",
+                "gs/pw": "pw",
+                "gs/mj": "mj",
+                "gs/pageant": "pageant",
+                "gs/scw": "scw&isil",
+                "gs/isil": "scw&isil",
+            },
+        )
+
+    # AE detector on real AE comments
+    def test_ae_ct_blp(self, ae_detector):
+        assert ae_detector.detect(
+            "Violations of the [[WP:BLP|biographies of living persons policy]] - [[WP:CT/BLP]]; requested at [[WP:RfPP]]"
+        ) == "blp"
+
+    def test_ae_ct_gg(self, ae_detector):
+        assert ae_detector.detect(
+            "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcment: [[WP:CT/GG]]; requested at [[WP:RfPP]]"
+        ) == "gg"
+
+    def test_ae_ct_imh(self, ae_detector):
+        assert ae_detector.detect(
+            "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/IMH]]"
+        ) == "imh"
+
+    def test_ae_ct_sa(self, ae_detector):
+        assert ae_detector.detect(
+            "Persistent [[WP:Disruptive editing|disruptive editing]] - arbitration enforcement: [[WP:CT/SA]]; requested at [[WP:RfPP]]"
+        ) == "sa"
+
+    def test_ae_blpct(self, ae_detector):
+        assert ae_detector.detect(
+            "[[WP:CTOP|Contentious topic]] restriction: [[WP:BLPCT]]"
+        ) == "blp"
+
+    # GS detector on real GS comments
+    def test_gs_kurd(self, gs_detector):
+        assert gs_detector.detect("Per [[WP:GS/KURD]]") == "kurd"
+
+    def test_gs_aa_full_page(self, gs_detector):
+        assert gs_detector.detect(
+            "[[Wikipedia:General sanctions/Armenia and Azerbaijan]]"
+        ) == "aa"
+
+    def test_gs_pw(self, gs_detector):
+        assert gs_detector.detect("Enforcement for [[WP:GS/PW]]") == "pw"
+
+    def test_gs_mj(self, gs_detector):
+        assert gs_detector.detect(
+            "Persistent [[WP:Disruptive editing|disruptive editing]] - [[WP:GS/MJ]]; requested at [[WP:RfPP]]"
+        ) == "mj"
+
+    def test_gs_rusukr(self, gs_detector):
+        assert gs_detector.detect("[[WP:GS/RUSUKR]]") == "rusukr"
+
+    def test_gs_rusukr_full_page(self, gs_detector):
+        assert gs_detector.detect(
+            "Per [[Wikipedia:General sanctions/Russo-Ukrainian war]]"
+        ) == "rusukr"
+
+    def test_gs_acas(self, gs_detector):
+        assert gs_detector.detect(
+            "[[WP:GS#Community sanctions|Community sanctions enforcement]]: per [[WP:GS/ACAS]]"
+        ) == "acas"
+
+    def test_gs_pageant(self, gs_detector):
+        assert gs_detector.detect(
+            "[[WP:GS#Community sanctions|Community sanctions enforcement]]: per RFPP and [[WP:GS/PAGEANT]]"
+        ) == "pageant"
+
+    # Dual-authority: AE detector gets AE code, GS detector gets GS code
+    def test_dual_ae_detector_gets_kurd(self, ae_detector):
+        assert ae_detector.detect(
+            "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]"
+        ) == "kurd"
+
+    def test_dual_gs_detector_gets_kurd(self, gs_detector):
+        assert gs_detector.detect(
+            "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/KURD]]/[[WP:GS/KURD]]"
+        ) == "kurd"
+
+    def test_dual_ae_detector_on_ct_aa(self, ae_detector):
+        comment = "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/AA]]/[[WP:GS/AA]]; requested at [[WP:RfPP]]"
+        # AE detector extracts "aa" from CT/AA shortcut, but the AE code is "a-a" not "aa".
+        # The shortcut regex extracts "aa" which isn't in AE codes, so it falls through
+        # to bare-code matching where "a-a" also won't match "aa".
+        # This documents a real config gap: CT/AA needs an override or code alias.
+        result = ae_detector.detect(comment)
+        assert result == ""  # Documents current behavior — needs config fix
+
+    def test_dual_gs_detector_gets_aa(self, gs_detector):
+        assert gs_detector.detect(
+            "[[WP:30/500|Arbitration enforcement]] - [[WP:CT/AA]]/[[WP:GS/AA]]"
+        ) == "aa"
+
+    # Cross-detector: AE detector should NOT detect GS codes, and vice versa
+    def test_ae_detector_ignores_gs_comment(self, ae_detector):
+        assert ae_detector.detect("Per [[WP:GS/RUSUKR]]") == ""
+
+    def test_gs_detector_ignores_ae_comment(self, gs_detector):
+        # GS detector doesn't have "blp" code
+        result = gs_detector.detect(
+            "Violations of the [[WP:BLP|biographies of living persons policy]] - [[WP:CT/BLP]]"
+        )
+        assert result == ""


### PR DESCRIPTION
## Summary
- Adds `is_community_sanction()` filter for detecting community general sanction protection actions
- Adds GS fields to `BotConfig` (`CLERKBOT_GS_TARGET_PAGE`, `CLERKBOT_GS_NOTIFY_ADMINS`, `CLERKBOT_GS_NOTIFICATIONS_DRYRUN_PAGE`)
- Updates `load_topics()` to return both AE and GS `TopicDetector` instances from merged on-wiki config
- Extracts `_run_pipeline()` helper from `main()` to avoid duplication
- Wires up GS pipeline to run after AE pipeline when configured
- GS notifications default to disabled

Closes #5

## Test plan
- [ ] All existing AE tests pass unchanged
- [ ] New GS filter tests verify trigger matching and no false positives
- [ ] New config tests verify GS env var loading and defaults
- [ ] New topic detector tests verify GS-specific detection
- [ ] Dual-pipeline tests verify dedup and filter independence
- [ ] Manual test with `CLERKBOT_GS_TARGET_PAGE` set to a test page